### PR TITLE
Fix resend task when order is missing

### DIFF
--- a/src/telegram/webhook.js
+++ b/src/telegram/webhook.js
@@ -42,8 +42,13 @@ router.post('/', async (req, res) => {
         await sendMessage(chatId, `🔁 Request new proof for ${invoice}`);
       } else if (data.startsWith('resend:')) {
         const invoice = data.split(':')[1];
-        await prisma.tasks.create({ data:{ order_id: (await prisma.orders.findUnique({ where:{ invoice } })).id, kind:'RESEND_INVITE' } });
-        await sendMessage(chatId, `🔁 Resend task queued for ${invoice}`);
+        const order = await prisma.orders.findUnique({ where:{ invoice } });
+        if(order){
+          await prisma.tasks.create({ data:{ order_id: order.id, kind:'RESEND_INVITE' } });
+          await sendMessage(chatId, `🔁 Resend task queued for ${invoice}`);
+        } else {
+          await sendMessage(chatId, `❌ Order ${invoice} not found`);
+        }
       }
       return res.sendStatus(200);
     }


### PR DESCRIPTION
## Summary
- handle missing order in Telegram `resend` action to avoid crashing

## Testing
- `TELEGRAM_BOT_TOKEN=1 ADMIN_CHAT_ID=1 WEBHOOK_SECRET_PATH=secret DATABASE_URL=postgresql://user:pass@localhost:5432/db ENCRYPTION_KEY=c3VwZXJzZWNyZXRrZXlzZWNyZXRrZXlzZWNyZXRrZXk= node server.js & pid=$!; sleep 1; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_68b8094296188329bf1f29b392cf240a