### PR TITLE
Improve setup docs and guard database tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,78 @@
+# Bot Backend
 
-# Bot Backend — FINAL (Stable for Railway)
+Backend Express + Prisma untuk Telegram dan WhatsApp.
 
-- Start aman: **node server.js** (dipaksa Procfile + nixpacks)
-- Prisma schema valid (baris per baris)
-- Opsional `MIGRATE_ON_BOOT=true` untuk migrate saat boot
-- Telegram admin: `/id`, `/start`, `/on`, `/off`, `/sheet_sync`, `/grid`, `/produk`, kartu ✅/❌/Mark/Resend
-- WhatsApp: QRIS via **MEDIA_ID** (hemat kredit Railway) + fallback URL/teks
+## Prasyarat
+- Node.js ≥18
+- PostgreSQL
+- Domain dengan HTTPS (untuk webhook Telegram)
 
-## Jalankan cepat
-```bash
-npm i
-npx prisma db push     # buat schema ke DB
-npm run seed           # isi data awal
-npm start
-```
-
-## Deploy Railway
-- Start Command: **node server.js**
-- Sekali saat deploy: `npm run deploy:migrate && npm run seed`
-- Set webhook Telegram ke: `$PUBLIC_URL/webhook/telegram/$WEBHOOK_SECRET_PATH`
-
-## Deploy Alibaba Cloud ECS
-1. Buat instance ECS dengan Node.js 18 atau lebih baru.
-2. Buka port yang digunakan aplikasi (default 3000) di security group.
-3. Clone repo dan masuk ke direktori proyek.
-4. Pasang dependensi dan inisialisasi database:
+## Setup
+1. Salin `.env.example` menjadi `.env` dan isi kredensial penting:
+   ```env
+   DATABASE_URL=postgresql://bw5user:password@localhost:5432/bw5db?schema=public
+   TELEGRAM_BOT_TOKEN=123456:ABCDEF
+   ADMIN_CHAT_ID=1696238182
+   WEBHOOK_SECRET_PATH=secret123
+   PUBLIC_URL=https://yourdomain.com
+   ```
+   Variabel lain seperti `WA_*` dan `SHEET_*` bersifat opsional.
+2. Siapkan database PostgreSQL:
+   ```bash
+   createuser -P bw5user
+   createdb -O bw5user bw5db
+   ```
+3. Inisialisasi schema dan data awal:
    ```bash
    npm install
-   npx prisma db push
-   npm run seed    # opsional
+   npx prisma migrate deploy
+   node src/preflight/guard.js      # tambah kolom bila belum ada
+   npm run seed                      # isi produk default
    ```
-5. Jalankan server:
+4. Jalankan server:
    ```bash
    npm start
    ```
-6. (Opsional) Gunakan PM2 atau systemd agar proses tetap berjalan.
+   Endpoint yang tersedia:
+   - `/healthz` → cek DB
+   - `/status` → ringkasan produk/akun/order
+   - `/webhook/telegram/:secret`
+   - `/webhook/wa`
+
+## Telegram Webhook
+Pastikan domain sudah HTTPS, kemudian set webhook:
+```bash
+curl -F "url=https://YOUR_DOMAIN/webhook/telegram/$WEBHOOK_SECRET_PATH" \
+  https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook
+```
+
+## Nginx + SSL
+Contoh konfigurasi `/etc/nginx/sites-available/bot.conf`:
+```nginx
+server {
+    server_name yourdomain.com;
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+Aktifkan dan pasang sertifikat:
+```bash
+ln -s /etc/nginx/sites-available/bot.conf /etc/nginx/sites-enabled/
+nginx -t && systemctl reload nginx
+certbot --nginx -d yourdomain.com
+```
+
+## PM2
+Agar bot berjalan otomatis setelah reboot:
+```bash
+pm2 start ecosystem.config.js
+pm2 save
+pm2 startup   # jalankan perintah yang muncul
+```
+
+## Catatan
+- Worker hanya berjalan jika tabel `orders` tersedia sehingga log tidak spam saat DB kosong.
+- Set `MIGRATE_ON_BOOT=true` bila ingin Prisma migrate otomatis saat start.

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [
+    {
+      name: 'bot-backend',
+      script: 'server.js',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,3 @@
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -88,65 +87,72 @@ enum Channel {
 }
 
 model products {
-  code            String   @id
+  code            String       @id
   name            String
   delivery_mode   DeliveryMode
   duration_months Int?
   price_cents     Int
-  requires_email  Boolean  @default(false)
-  is_active       Boolean  @default(true)
+  requires_email  Boolean      @default(false)
+  is_active       Boolean      @default(true)
   daily_limit     Int?
   sk_text         String?
 
-  accounts        accounts[]
-  orders          orders[]
+  accounts accounts[]
+  orders   orders[]
 
-  created_at      DateTime @default(now())
-  updated_at      DateTime @updatedAt
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
 }
 
 model accounts {
-  id             Int           @id @default(autoincrement())
-  product_code   String
-  username       String
-  password_enc   String
-  otp_secret_enc String?
-  status         AccountStatus @default(AVAILABLE)
-  max_uses       Int           @default(1)
-  current_uses   Int           @default(0)
+  id               Int           @id @default(autoincrement())
+  product_code     String
+  username         String
+  password_enc     String
+  otp_secret_enc   String?
+  otp_seed         String?
+  invite_api       String?
+  variant_type     String?
+  variant_duration Int?
+  price_override   Int?
+  tnc              String?
+  status           AccountStatus @default(AVAILABLE)
+  max_uses         Int           @default(1)
+  current_uses     Int           @default(0)
 
-  product        products      @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
-  orders         orders[]      @relation("OrderAccount")
+  product products @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
+  orders  orders[] @relation("OrderAccount")
 
-  created_at     DateTime      @default(now())
-  updated_at     DateTime      @updatedAt
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
 
+  @@unique([product_code, username], name: "product_code_username")
   @@index([status])
   @@index([product_code])
-  @@unique([product_code, username], name: "product_code_username")
 }
 
 model orders {
-  id           BigInt        @id @default(autoincrement())
-  invoice      String        @unique
-  buyer_phone  String
-  product_code String
-  qty          Int           @default(1)
-  amount_cents Int
-  status       OrderStatus   @default(PENDING_PAYMENT)
-  email        String?
-  account_id   Int?
-  pay_ack_at   DateTime?
-  proof_id     String?
-  proof_mime   String?
+  id              BigInt      @id @default(autoincrement())
+  invoice         String      @unique
+  buyer_phone     String
+  product_code    String
+  qty             Int         @default(1)
+  amount_cents    Int
+  status          OrderStatus @default(PENDING_PAYMENT)
+  email           String?
+  account_id      Int?
+  pay_ack_at      DateTime?
+  proof_id        String?
+  proof_mime      String?
+  synced_to_sheet Boolean     @default(false)
 
-  product      products      @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
-  account      accounts?     @relation("OrderAccount", fields: [account_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
-  events       events[]
-  tasks        tasks[]
+  product products  @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
+  account accounts? @relation("OrderAccount", fields: [account_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  events  events[]
+  tasks   tasks[]
 
-  created_at   DateTime      @default(now())
-  updated_at   DateTime      @updatedAt
+  created_at DateTime @default(now())
+  updated_at DateTime @updatedAt
 
   @@index([status])
   @@index([product_code, created_at])
@@ -154,16 +160,16 @@ model orders {
 }
 
 model events {
-  id               BigInt     @id @default(autoincrement())
-  order_id         BigInt?
-  kind             EventKind
-  actor            Actor      @default(SYSTEM)
-  source           String?
-  meta             Json?
-  idempotency_key  String?
-  created_at       DateTime   @default(now())
+  id              BigInt    @id @default(autoincrement())
+  order_id        BigInt?
+  kind            EventKind
+  actor           Actor     @default(SYSTEM)
+  source          String?
+  meta            Json?
+  idempotency_key String?
+  created_at      DateTime  @default(now())
 
-  order            orders?    @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  order orders? @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
 
   @@index([order_id, created_at])
   @@index([kind])
@@ -180,7 +186,7 @@ model tasks {
   created_at DateTime   @default(now())
   updated_at DateTime   @updatedAt
 
-  order      orders     @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  order orders @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
 
   @@index([status, due_at])
 }
@@ -192,11 +198,11 @@ model settings {
 }
 
 model otptokens {
-  id          String   @id
-  order_id    BigInt
-  expires_at  DateTime
-  used        Boolean  @default(false)
-  created_at  DateTime @default(now())
+  id         String   @id
+  order_id   BigInt
+  expires_at DateTime
+  used       Boolean  @default(false)
+  created_at DateTime @default(now())
 
   @@index([order_id, expires_at])
 }
@@ -213,9 +219,9 @@ model deadletters {
 }
 
 model ratelogs {
-  id    BigInt   @id @default(autoincrement())
-  key   String
-  ts    DateTime @default(now())
+  id  BigInt   @id @default(autoincrement())
+  key String
+  ts  DateTime @default(now())
 
   @@index([key, ts])
 }

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const waWebhook = require('./src/whatsapp/webhook');
 const { startWorkers } = require('./src/services/worker');
 const { requestLogger } = require('./src/utils/logger');
 const { migrateIfEnabled } = require('./src/preflight/migrate');
+const { runGuard } = require('./src/preflight/guard');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -55,7 +56,8 @@ const server = app.listen(PORT, async () => {
   if (process.env.PUBLIC_URL) console.log(`Public URL: ${process.env.PUBLIC_URL}`);
   console.log(`Telegram webhook mounted at: ${tgPath}`);
   await migrateIfEnabled();
-  startWorkers();
+  await runGuard();
+  await startWorkers();
 });
 
 process.on('SIGTERM', () => { console.log('SIGTERM received, closing...'); server.close(() => process.exit(0)); });

--- a/src/preflight/guard.js
+++ b/src/preflight/guard.js
@@ -1,0 +1,22 @@
+const prisma = require('../db/client');
+
+async function runGuard() {
+  const queries = [
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS otp_seed TEXT`,
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS invite_api TEXT`,
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS variant_type TEXT`,
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS variant_duration INTEGER`,
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS price_override INTEGER`,
+    `ALTER TABLE IF NOT EXISTS accounts ADD COLUMN IF NOT EXISTS tnc TEXT`,
+    `ALTER TABLE IF NOT EXISTS orders ADD COLUMN IF NOT EXISTS synced_to_sheet BOOLEAN NOT NULL DEFAULT FALSE`,
+  ];
+  for (const q of queries) {
+    try {
+      await prisma.$executeRawUnsafe(q);
+    } catch (e) {
+      console.error('[preflight] guard error', e.message);
+    }
+  }
+}
+
+module.exports = { runGuard };

--- a/src/services/worker.js
+++ b/src/services/worker.js
@@ -89,7 +89,13 @@ async function retryDeadLetters(){
   }
 }
 
-function startWorkers(){
+async function startWorkers(){
+  try {
+    await prisma.orders.findFirst({ select:{ id:true }, take:1 });
+  } catch(e) {
+    if(e.code === 'P2021') { console.log('Workers skipped: tables not ready'); return; }
+    throw e;
+  }
   setInterval(wrap(expireOrders,'expireOrders'), minutes(1));
   setInterval(wrap(remindPayments,'remindPayments'), minutes(1));
   setInterval(wrap(checkStockAndPause,'checkStockAndPause'), minutes(5));


### PR DESCRIPTION
## Summary
- add missing account/order fields and schema guard script
- ensure workers only start when tables exist
- document full setup with env, webhook, nginx, and PM2

## Testing
- `npx --yes prisma format`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db npx --yes prisma validate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8d90fcb3483299a879af78e7bfa05