### PR TITLE
feat: add utility helpers for currency formatting and refunds

### DIFF
--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,13 @@
+const formatter = new Intl.NumberFormat('id-ID', {
+  style: 'currency',
+  currency: 'IDR',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+function formatRupiah(amountCents) {
+  const amount = Math.floor(amountCents / 100);
+  return formatter.format(amount);
+}
+
+module.exports = { formatRupiah };

--- a/src/utils/refund.js
+++ b/src/utils/refund.js
@@ -1,0 +1,7 @@
+function calcLinearRefund({ priceCents, warrantyDays, usedDays }) {
+  if (warrantyDays <= 0) return 0;
+  const remaining = Math.max(0, warrantyDays - usedDays);
+  return Math.floor((remaining / warrantyDays) * priceCents);
+}
+
+module.exports = { calcLinearRefund };

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,18 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { formatRupiah } = require('../src/utils/currency');
+const { calcLinearRefund } = require('../src/utils/refund');
+
+test('formatRupiah formats cents into IDR', () => {
+  assert.strictEqual(formatRupiah(150000), 'Rp 1.500');
+});
+
+test('calcLinearRefund prorates linearly', () => {
+  const price = 10000; // 100 IDR
+  const warranty = 10; // days
+  assert.strictEqual(calcLinearRefund({ priceCents: price, warrantyDays: warranty, usedDays: 0 }), price);
+  assert.strictEqual(calcLinearRefund({ priceCents: price, warrantyDays: warranty, usedDays: 5 }), 5000);
+  assert.strictEqual(calcLinearRefund({ priceCents: price, warrantyDays: warranty, usedDays: 10 }), 0);
+  assert.strictEqual(calcLinearRefund({ priceCents: price, warrantyDays: warranty, usedDays: 15 }), 0);
+});


### PR DESCRIPTION
## Summary
- add `formatRupiah` helper for IDR currency formatting
- add `calcLinearRefund` helper for prorated refunds
- cover new helpers with basic unit tests using `node:test`

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ba342d561483298549863a084d676b