### PR TITLE
feat: add stock options endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ Backend Express + Prisma untuk Telegram dan WhatsApp.
    Endpoint yang tersedia:
    - `/healthz` → cek DB
    - `/status` → ringkasan produk/akun/order
+   - `/stock/options?productId=PROD` → stok durasi per produk
    - `/webhook/telegram/:secret`
    - `/webhook/wa`
+
+   Contoh mengambil stok:
+   ```bash
+   curl "https://yourdomain.com/stock/options?productId=CHATGPT"
+   ```
 
 ## Telegram Webhook
 Pastikan domain sudah HTTPS, kemudian set webhook:

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const compression = require('compression');
 const helmet = require('helmet');
 const health = require('./src/routes/health');
 const status = require('./src/routes/status');
+const stock = require('./src/routes/stock');
 const telegramWebhook = require('./src/telegram/webhook');
 const waWebhook = require('./src/whatsapp/webhook');
 const { startWorkers } = require('./src/services/worker');
@@ -41,6 +42,7 @@ app.use((req, res, next) => {
 
 app.use('/healthz', health);
 app.use('/status', status);
+app.use('/stock', stock);
 
 const tgPath = process.env.WEBHOOK_SECRET_PATH ? `/webhook/telegram/${process.env.WEBHOOK_SECRET_PATH}` : '/webhook/telegram';
 app.use(tgPath, telegramWebhook);

--- a/src/routes/stock.js
+++ b/src/routes/stock.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const { getStockOptions } = require('../services/stock');
+
+const router = express.Router();
+
+router.get('/options', async (req, res) => {
+  const { productId } = req.query;
+  if (!productId) return res.status(400).json({ ok: false, error: 'MISSING_PRODUCT_ID' });
+  try {
+    const opts = await getStockOptions(productId);
+    res.json(opts);
+  } catch (err) {
+    console.error('stock options error', err);
+    res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+module.exports = router;

--- a/src/services/stock.js
+++ b/src/services/stock.js
@@ -1,0 +1,22 @@
+const prisma = require('../db/client');
+
+function computeOptions(accounts) {
+  const map = new Map();
+  for (const { variant_duration } of accounts) {
+    const days = variant_duration || 0;
+    map.set(days, (map.get(days) || 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([durationDays, stock]) => ({ durationDays, stock }))
+    .sort((a, b) => a.durationDays - b.durationDays);
+}
+
+async function getStockOptions(productId) {
+  const rows = await prisma.accounts.findMany({
+    where: { product_code: productId, status: 'AVAILABLE' },
+    select: { variant_duration: true },
+  });
+  return computeOptions(rows);
+}
+
+module.exports = { computeOptions, getStockOptions };

--- a/test/stock.test.js
+++ b/test/stock.test.js
@@ -1,0 +1,18 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { computeOptions } = require('../src/services/stock');
+
+test('computeOptions aggregates by duration', () => {
+  const accounts = [
+    { variant_duration: 30 },
+    { variant_duration: 30 },
+    { variant_duration: 60 },
+    { variant_duration: null },
+  ];
+  assert.deepStrictEqual(computeOptions(accounts), [
+    { durationDays: 0, stock: 1 },
+    { durationDays: 30, stock: 2 },
+    { durationDays: 60, stock: 1 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add stock service to aggregate duration-based stock counts
- expose GET /stock/options endpoint for stock lookup
- document stock endpoint and example usage

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68ba35dc639883299c567beac9811852