### PR TITLE
feat: parse approval flag from sheet

### DIFF
--- a/src/services/sheet.js
+++ b/src/services/sheet.js
@@ -3,6 +3,18 @@ const prisma = require('../db/client');
 const { SHEET_MODE, SHEET_CSV_URL, SHEET_SECRET } = require('../config/env');
 const { notifyCritical } = require('./telegram');
 
+/**
+ * Parse "approval_required" column coming from spreadsheet.
+ * Only exact string "On" (case sensitive) should be treated as true.
+ * Anything else including empty string, "off", etc results in false.
+ * This helper is exported for unit tests.
+ * @param {string|undefined|null} v
+ * @returns {boolean}
+ */
+function parseApprovalRequired(v) {
+  return v === 'On';
+}
+
 function parseCSV(text){
   const lines = text.split(/\r?\n/).filter(Boolean);
   const header = lines.shift().split(',').map(s=>s.trim());
@@ -48,4 +60,4 @@ async function syncAccountsFromCSV(){
   }
 }
 
-module.exports = { syncAccountsFromCSV };
+module.exports = { syncAccountsFromCSV, parseApprovalRequired };

--- a/test/sheet.test.js
+++ b/test/sheet.test.js
@@ -1,0 +1,12 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { parseApprovalRequired } = require('../src/services/sheet');
+
+test('parseApprovalRequired only accepts exact "On"', () => {
+  assert.strictEqual(parseApprovalRequired('On'), true);
+  assert.strictEqual(parseApprovalRequired('on'), false);
+  assert.strictEqual(parseApprovalRequired('Off'), false);
+  assert.strictEqual(parseApprovalRequired(''), false);
+  assert.strictEqual(parseApprovalRequired(undefined), false);
+});


### PR DESCRIPTION
## Summary
- parse `approval_required` column from spreadsheet as boolean
- cover parser with unit tests

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3c12b7808329bb38e6df1da585be