### PR TITLE
feat: add n8n integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ PUBLIC_URL=https://app.up.railway.app
 ENCRYPTION_KEY=c3VwZXJzZWNyZXRrZXlzZWNyZXRrZXlzZWNyZXRrZXk=
 JWT_SECRET=supersecretjwt
 
+# n8n integration
+N8N_WEBHOOK_BASE=
+
 # WHATSAPP (opsional lokal)
 WA_ACCESS_TOKEN=
 WA_VERIFY_TOKEN=verifytoken

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ Jalankan seluruh tes unit:
 npm test
 ```
 
+## Integrasi n8n
+Backend dapat mengirim setiap event order ke workflow n8n sehingga otomatisasi bisa dilakukan tanpa mengubah kode.
+
+1. Buat workflow di n8n dengan trigger **Webhook**. Catat URL webhook yang dihasilkan, misal `https://n8n.example/webhook/bw5/`.
+2. Isi variabel `N8N_WEBHOOK_BASE` pada `.env` dengan URL tersebut (boleh menyertakan path tambahan, harus diakhiri `/`).
+3. Jalankan ulang server. Setiap event yang tersimpan melalui `addEvent` akan dikirim sebagai JSON ke `N8N_WEBHOOK_BASE + 'events'`.
+4. Di n8n, gunakan data JSON tersebut untuk melanjutkan otomatisasi (update spreadsheet, kirim notifikasi, dll).
+
+Contoh payload yang dikirim:
+```json
+{
+  "orderId": 1,
+  "kind": "ORDER_CREATED",
+  "message": "Order INV-123 created",
+  "meta": {},
+  "actor": "SYSTEM",
+  "source": "system"
+}
+```
+
 ## Telegram Webhook
 Pastikan domain sudah HTTPS, kemudian set webhook:
 ```bash

--- a/src/services/events.js
+++ b/src/services/events.js
@@ -1,6 +1,15 @@
 
 const prisma = require('../db/client');
+const { sendToN8n } = require('../utils/n8n');
+
 async function addEvent(orderId, kind, message, meta={}, actor='SYSTEM', source='system', idempotency_key=null){
-  try{ return await prisma.events.create({ data:{ order_id: orderId||null, kind, actor, source, meta:{ message, ...meta }, idempotency_key } }); }catch(e){ return null; }
+  try{
+    const ev = await prisma.events.create({ data:{ order_id: orderId||null, kind, actor, source, meta:{ message, ...meta }, idempotency_key } });
+    sendToN8n('events', { orderId, kind, message, meta, actor, source }).catch(()=>{});
+    return ev;
+  }catch(e){
+    return null;
+  }
 }
+
 module.exports = { addEvent };

--- a/src/utils/n8n.js
+++ b/src/utils/n8n.js
@@ -1,0 +1,26 @@
+function buildUrl(path){
+  const base = process.env.N8N_WEBHOOK_BASE;
+  if(!base) return null;
+  const trimmed = base.endsWith('/') ? base : base + '/';
+  return trimmed + (path || '').replace(/^\//,'');
+}
+
+async function sendToN8n(path, payload){
+  const url = buildUrl(path);
+  if(!url) return;
+  try{
+    const res = await fetch(url, {
+      method:'POST',
+      headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if(!res.ok){
+      const text = await res.text();
+      console.error('n8n error', res.status, text);
+    }
+  }catch(e){
+    console.error('n8n request failed', e);
+  }
+}
+
+module.exports = { sendToN8n };


### PR DESCRIPTION
## Summary
- add utility to send events to n8n webhooks
- forward order events to n8n when available
- document n8n integration and env variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba46faf8dc8329bfe2a4717506ffea