### PR TITLE
feat: secure n8n bridge with deadletter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,8 @@ ENCRYPTION_KEY=c3VwZXJzZWNyZXRrZXlzZWNyZXRrZXlzZWNyZXRrZXk=
 JWT_SECRET=supersecretjwt
 
 # n8n integration
-N8N_WEBHOOK_BASE=
+N8N_BASE_URL=https://automations.example.com/webhook
+N8N_TOKEN=internal-secret
 
 # WHATSAPP (opsional lokal)
 WA_ACCESS_TOKEN=

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ npm test
 ## Integrasi n8n
 Backend dapat mengirim setiap event order ke workflow n8n sehingga otomatisasi bisa dilakukan tanpa mengubah kode.
 
-1. Buat workflow di n8n dengan trigger **Webhook**. Catat URL webhook yang dihasilkan, misal `https://n8n.example/webhook/bw5/`.
-2. Isi variabel `N8N_WEBHOOK_BASE` pada `.env` dengan URL tersebut (boleh menyertakan path tambahan, harus diakhiri `/`).
-3. Jalankan ulang server. Setiap event yang tersimpan melalui `addEvent` akan dikirim sebagai JSON ke `N8N_WEBHOOK_BASE + 'events'`.
+1. Buat workflow di n8n dengan trigger **Webhook**. Catat URL webhook yang dihasilkan, misal `https://n8n.example/webhook/bw5`.
+2. Isi variabel `N8N_BASE_URL` pada `.env` dengan URL tersebut dan `N8N_TOKEN` dengan secret internal token.
+3. Jalankan ulang server. Setiap event yang tersimpan melalui `addEvent` akan dikirim sebagai JSON ke `N8N_BASE_URL + '/events'` dengan header `X-Internal-Token`.
 4. Di n8n, gunakan data JSON tersebut untuk melanjutkan otomatisasi (update spreadsheet, kirim notifikasi, dll).
 
 Contoh payload yang dikirim:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,7 @@ enum TaskStatus {
 enum Channel {
   TELEGRAM
   WHATSAPP
+  N8N
 }
 
 enum PreapprovalStatus {

--- a/src/services/events.js
+++ b/src/services/events.js
@@ -1,11 +1,11 @@
 
 const prisma = require('../db/client');
-const { sendToN8n } = require('../utils/n8n');
+const { emitToN8N } = require('../utils/n8n');
 
 async function addEvent(orderId, kind, message, meta={}, actor='SYSTEM', source='system', idempotency_key=null){
   try{
     const ev = await prisma.events.create({ data:{ order_id: orderId||null, kind, actor, source, meta:{ message, ...meta }, idempotency_key } });
-    sendToN8n('events', { orderId, kind, message, meta, actor, source }).catch(()=>{});
+    emitToN8N('/events', { orderId, kind, message, meta, actor, source });
     return ev;
   }catch(e){
     return null;

--- a/src/services/worker.js
+++ b/src/services/worker.js
@@ -4,6 +4,7 @@ const { SHEET_POLL_MS, PAYMENT_DEADLINE_MIN } = require('../config/env');
 const { syncAccountsFromCSV } = require('./sheet');
 const { notifyAdmin, notifyCritical, tgCall } = require('./telegram');
 const { waCall } = require('./wa');
+const { sendToN8N } = require('../utils/n8n');
 
 function minutes(n){ return n*60*1000; }
 
@@ -79,6 +80,7 @@ async function retryDeadLetters(){
     try {
       if (d.channel === 'TELEGRAM') await tgCall(d.endpoint || 'sendMessage', d.payload);
       else if (d.channel === 'WHATSAPP') await waCall(d.endpoint || 'messages', d.payload);
+      else if (d.channel === 'N8N') await sendToN8N(d.endpoint || '', d.payload);
       await prisma.deadletters.delete({ where:{ id: d.id } });
     } catch (e) {
       await prisma.deadletters.update({

--- a/src/utils/n8n.js
+++ b/src/utils/n8n.js
@@ -1,26 +1,47 @@
-function buildUrl(path){
-  const base = process.env.N8N_WEBHOOK_BASE;
-  if(!base) return null;
-  const trimmed = base.endsWith('/') ? base : base + '/';
-  return trimmed + (path || '').replace(/^\//,'');
+const prisma = require('../db/client');
+
+function buildUrl(path) {
+  const base = process.env.N8N_BASE_URL;
+  if (!base) return null;
+  const trimmed = base.endsWith('/') ? base.slice(0, -1) : base;
+  return `${trimmed}/${(path || '').replace(/^\//, '')}`;
 }
 
-async function sendToN8n(path, payload){
+async function sendToN8N(path, payload) {
   const url = buildUrl(path);
-  if(!url) return;
-  try{
-    const res = await fetch(url, {
-      method:'POST',
-      headers:{ 'Content-Type':'application/json' },
-      body: JSON.stringify(payload)
-    });
-    if(!res.ok){
-      const text = await res.text();
-      console.error('n8n error', res.status, text);
-    }
-  }catch(e){
-    console.error('n8n request failed', e);
+  if (!url) throw new Error('N8N_BASE_URL not set');
+  const token = process.env.N8N_TOKEN || '';
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Token': token,
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status}: ${text}`);
   }
 }
 
-module.exports = { sendToN8n };
+async function emitToN8N(path, payload) {
+  try {
+    await sendToN8N(path, payload);
+  } catch (e) {
+    try {
+      await prisma.deadletters.create({
+        data: {
+          channel: 'N8N',
+          endpoint: path,
+          payload,
+          error: e.message,
+        },
+      });
+    } catch (_) {
+      // ignore if DB not ready
+    }
+  }
+}
+
+module.exports = { emitToN8N, sendToN8N };


### PR DESCRIPTION
## Summary
- add N8N channel to schema for reliable internal automation
- bridge events to n8n with token auth and deadletter fallback
- include n8n deadletter retry in worker and document new env vars

## Testing
- `npm test`
- `npx prisma migrate dev -n "n8n-channel"` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5308671c8329bc8a60585a9c7afc