### PR TITLE
feat: add preapproval and warranty flows

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,14 @@ enum Channel {
   N8N
 }
 
+enum ClaimStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  AWAITING_REFUND
+  REFUNDED
+}
+
 enum PreapprovalStatus {
   PENDING
   APPROVED
@@ -195,6 +203,28 @@ model preapprovalrequests {
 
   created_at DateTime @default(now())
   updated_at DateTime @updatedAt
+}
+
+model warrantyclaims {
+  id          BigInt     @id @default(autoincrement())
+  order_id    BigInt     @unique
+  status      ClaimStatus @default(PENDING)
+  reason      String?
+  refund_cents Int?
+  ewallet     String?
+  created_at  DateTime   @default(now())
+  updated_at  DateTime   @updatedAt
+
+  order orders @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
+}
+
+model stockalerts {
+  id           Int      @id @default(autoincrement())
+  product_code String   @unique
+  in_stock     Boolean  @default(true)
+  updated_at   DateTime @updatedAt
+
+  product products @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Cascade)
 }
 
 model events {

--- a/server.js
+++ b/server.js
@@ -5,6 +5,8 @@ const helmet = require('helmet');
 const health = require('./src/routes/health');
 const status = require('./src/routes/status');
 const stock = require('./src/routes/stock');
+const preapprovals = require('./src/routes/preapprovals');
+const claims = require('./src/routes/claims');
 const telegramWebhook = require('./src/telegram/webhook');
 const waWebhook = require('./src/whatsapp/webhook');
 const { startWorkers } = require('./src/services/worker');
@@ -40,6 +42,8 @@ app.use((req, res, next) => {
 app.use('/healthz', health);
 app.use('/status', status);
 app.use('/stock', stock);
+app.use('/preapprovals', preapprovals);
+app.use('/claims', claims);
 app.use('/webhook/wa', waWebhook);
 
 const tgPath = process.env.WEBHOOK_SECRET_PATH ? `/webhook/telegram/${process.env.WEBHOOK_SECRET_PATH}` : '/webhook/telegram';

--- a/src/routes/claims.js
+++ b/src/routes/claims.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const router = express.Router();
+
+const { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded } = require('../services/claims');
+
+router.post('/', async (req, res) => {
+  try {
+    const { invoice, reason } = req.body || {};
+    const claim = await createClaim(invoice, reason);
+    res.json({ ok: true, claim });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/approve', async (req, res) => {
+  try {
+    await approveClaim(Number(req.params.id));
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/reject', async (req, res) => {
+  try {
+    await rejectClaim(Number(req.params.id), req.body?.reason);
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/ewallet', async (req, res) => {
+  try {
+    await setEwallet(Number(req.params.id), req.body?.ewallet);
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/refunded', async (req, res) => {
+  try {
+    await markRefunded(Number(req.params.id));
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+module.exports = router;
+

--- a/src/routes/preapprovals.js
+++ b/src/routes/preapprovals.js
@@ -1,0 +1,48 @@
+const express = require('express');
+const router = express.Router();
+
+const prisma = require('../db/client');
+const { approvePreapproval, rejectPreapproval } = require('../services/orders');
+const { sendText, sendImageById, sendImageByUrl } = require('../services/wa');
+const { PAYMENT_QRIS_TEXT, PAYMENT_QRIS_IMAGE_URL, PAYMENT_QRIS_MEDIA_ID, PAYMENT_DEADLINE_MIN } = require('../config/env');
+
+router.post('/:id/approve', async (req, res) => {
+  try {
+    const invoice = req.params.id;
+    const r = await approvePreapproval(invoice);
+    if (!r.ok) return res.status(400).json(r);
+
+    const order = await prisma.orders.findUnique({ where: { invoice } });
+    if (!order) return res.status(404).json({ ok: false, error: 'ORDER_NOT_FOUND' });
+    const deadlineAt = new Date(order.created_at.getTime() + PAYMENT_DEADLINE_MIN * 60 * 1000);
+    const caption = `${PAYMENT_QRIS_TEXT}\nInvoice: ${order.invoice}\nTotal: Rp ${(order.amount_cents) / 100}\nDeadline: ${deadlineAt.toLocaleTimeString()}\nKirim foto bukti bayar ke sini.`;
+    if (PAYMENT_QRIS_MEDIA_ID) await sendImageById(order.buyer_phone, PAYMENT_QRIS_MEDIA_ID, caption);
+    else if (PAYMENT_QRIS_IMAGE_URL) await sendImageByUrl(order.buyer_phone, PAYMENT_QRIS_IMAGE_URL, caption);
+    else await sendText(order.buyer_phone, caption);
+
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/reject', async (req, res) => {
+  try {
+    const invoice = req.params.id;
+    const reason = req.body?.reason;
+    const r = await rejectPreapproval(invoice, reason);
+    if (!r.ok) return res.status(400).json(r);
+
+    const order = await prisma.orders.findUnique({ where: { invoice }, include: { preapproval: true } });
+    if (order) {
+      const note = order.preapproval?.notes || '';
+      await sendText(order.buyer_phone, `❌ Order ditolak. ${note}`);
+    }
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+module.exports = router;
+

--- a/src/services/claims.js
+++ b/src/services/claims.js
@@ -1,0 +1,43 @@
+const prisma = require('../db/client');
+const { calcLinearRefund } = require('../utils/refund');
+const { emitToN8N } = require('../utils/n8n');
+const { appendWarrantyLog } = require('./sheet');
+
+async function createClaim(invoice, reason) {
+  const order = await prisma.orders.findUnique({ where: { invoice }, include: { product: true } });
+  if (!order) throw new Error('ORDER_NOT_FOUND');
+  const claim = await prisma.warrantyclaims.create({ data: { order_id: order.id, reason } });
+  await emitToN8N('/claim-created', { id: claim.id, invoice });
+  return claim;
+}
+
+async function approveClaim(id) {
+  const claim = await prisma.warrantyclaims.findUnique({ where: { id }, include: { order: { include: { product: true } } } });
+  if (!claim) throw new Error('CLAIM_NOT_FOUND');
+  const order = claim.order;
+  const warrantyDays = (order.product.duration_months || 0) * 30;
+  const usedDays = Math.floor((Date.now() - order.created_at.getTime()) / 86400000);
+  const refund = calcLinearRefund({ priceCents: order.amount_cents, warrantyDays, usedDays });
+  const upd = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'APPROVED', refund_cents: refund } });
+  await emitToN8N('/claim-approved', { id, refund_cents: refund });
+  return upd;
+}
+
+async function rejectClaim(id, reason) {
+  const upd = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'REJECTED', reason } });
+  await emitToN8N('/claim-rejected', { id, reason });
+  return upd;
+}
+
+async function setEwallet(id, ewallet) {
+  return prisma.warrantyclaims.update({ where: { id }, data: { ewallet, status: 'AWAITING_REFUND' } });
+}
+
+async function markRefunded(id) {
+  const claim = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'REFUNDED' }, include: { order: true } });
+  await appendWarrantyLog({ claimId: id, invoice: claim.order.invoice, refund_cents: claim.refund_cents, ewallet: claim.ewallet });
+  return claim;
+}
+
+module.exports = { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded };
+

--- a/src/telegram/webhook.js
+++ b/src/telegram/webhook.js
@@ -55,6 +55,28 @@ router.post('/', async (req, res) => {
           await answerCallbackQuery(update.callback_query.id, '❌ Not found');
           await sendMessage(chatId, `❌ Order ${invoice} not found`);
         }
+      } else if (data.startsWith('ADM:PREAPPROVE:OK:')) {
+        const invoice = data.split(':')[3];
+        const base = process.env.PUBLIC_URL || `http://localhost:${process.env.PORT||3000}`;
+        try {
+          await fetch(`${base}/preapprovals/${invoice}/approve`, { method:'POST', headers:{'Content-Type':'application/json'} });
+          await answerCallbackQuery(update.callback_query.id, '✅ Approved');
+          const newText = `${msg.text}\n✅ Disetujui`;
+          await editMessageText(chatId, msg.message_id, newText, { parse_mode: 'HTML' });
+        } catch (e) {
+          await answerCallbackQuery(update.callback_query.id, '❌ Fail');
+        }
+      } else if (data.startsWith('ADM:PREAPPROVE:NO:')) {
+        const invoice = data.split(':')[3];
+        const base = process.env.PUBLIC_URL || `http://localhost:${process.env.PORT||3000}`;
+        try {
+          await fetch(`${base}/preapprovals/${invoice}/reject`, { method:'POST', headers:{'Content-Type':'application/json'} });
+          await answerCallbackQuery(update.callback_query.id, '❌ Rejected');
+          const newText = `${msg.text}\n❌ Ditolak`;
+          await editMessageText(chatId, msg.message_id, newText, { parse_mode: 'HTML' });
+        } catch (e) {
+          await answerCallbackQuery(update.callback_query.id, '❌ Fail');
+        }
       }
       return res.sendStatus(200);
     }

--- a/src/utils/n8n.js
+++ b/src/utils/n8n.js
@@ -11,17 +11,25 @@ async function sendToN8N(path, payload) {
   const url = buildUrl(path);
   if (!url) throw new Error('N8N_BASE_URL not set');
   const token = process.env.N8N_TOKEN || '';
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Internal-Token': token,
-    },
-    body: JSON.stringify(payload),
-  });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`HTTP ${res.status}: ${text}`);
+  for (let i = 0; i < 3; i++) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Internal-Token': token,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`HTTP ${res.status}: ${text}`);
+      }
+      return;
+    } catch (e) {
+      if (i === 2) throw e;
+      await new Promise(r => setTimeout(r, 400 * (2 ** i)));
+    }
   }
 }
 

--- a/test/claim.test.js
+++ b/test/claim.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+const n8nPath = require.resolve('../src/utils/n8n');
+const eventPath = require.resolve('../src/services/events');
+
+const order = {
+  id: 1,
+  invoice: 'INV-1',
+  amount_cents: 10000,
+  created_at: new Date(Date.now() - 5 * 86400000),
+  product: { duration_months: 10 },
+};
+
+const store = {
+  warranty: [{ id: 1, order_id: 1, status: 'PENDING', reason: null }],
+};
+
+require.cache[dbPath] = { exports: {
+  warrantyclaims: {
+    findUnique: async ({ where }) => {
+      const c = store.warranty.find((x) => x.id === where.id);
+      if (!c) return null;
+      return { ...c, order };
+    },
+    update: async ({ where, data }) => {
+      const c = store.warranty.find((x) => x.id === where.id);
+      Object.assign(c, data);
+      return { ...c };
+    },
+  },
+} };
+
+require.cache[n8nPath] = { exports: { emitToN8N: async () => {} } };
+require.cache[eventPath] = { exports: { addEvent: async () => {} } };
+
+const { approveClaim } = require('../src/services/claims');
+const { calcLinearRefund } = require('../src/utils/refund');
+
+test('approveClaim calculates prorated refund', async () => {
+  const r = await approveClaim(1);
+  const expected = calcLinearRefund({ priceCents: order.amount_cents, warrantyDays: 300, usedDays: 5 });
+  assert.strictEqual(r.refund_cents, expected);
+  assert.strictEqual(r.status, 'APPROVED');
+});
+

--- a/test/preapproval.test.js
+++ b/test/preapproval.test.js
@@ -1,0 +1,43 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+const eventPath = require.resolve('../src/services/events');
+
+const store = { orders: [], preapps: [] };
+
+require.cache[dbPath] = { exports: {
+  subproductconfigs: {
+    findUnique: async ({ where }) => {
+      const sub = where.product_code_sub_code.sub_code;
+      if (sub === 'need') return { approval_required: true };
+      return null;
+    },
+  },
+  orders: {
+    create: async ({ data }) => {
+      const o = { id: store.orders.length + 1, ...data, created_at: new Date() };
+      store.orders.push(o);
+      return o;
+    },
+  },
+  preapprovalrequests: {
+    create: async ({ data }) => { store.preapps.push(data); },
+  },
+} };
+
+require.cache[eventPath] = { exports: { addEvent: async () => {} } };
+
+const { createOrder } = require('../src/services/orders');
+
+test('order requiring approval goes to AWAITING_PREAPPROVAL', async () => {
+  const o = await createOrder({ buyer_phone: '1', product_code: 'P', qty: 1, amount_cents: 100, sub_code: 'need' });
+  assert.strictEqual(o.status, 'AWAITING_PREAPPROVAL');
+  assert.strictEqual(store.preapps.length, 1);
+});
+
+test('order without approval goes to PENDING_PAYMENT', async () => {
+  const o = await createOrder({ buyer_phone: '1', product_code: 'P', qty: 1, amount_cents: 100, sub_code: 'none' });
+  assert.strictEqual(o.status, 'PENDING_PAYMENT');
+});
+

--- a/test/reserve.test.js
+++ b/test/reserve.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+const eventPath = require.resolve('../src/services/events');
+
+const store = {
+  accounts: [{ id: 1, product_code: 'P', status: 'AVAILABLE' }],
+  orders: [
+    { id: 1, product_code: 'P' },
+    { id: 2, product_code: 'P' },
+  ],
+};
+
+require.cache[dbPath] = { exports: {
+  $transaction: async (fn) => fn({
+    accounts: {
+      findFirst: async ({ where }) =>
+        store.accounts.find((a) => a.product_code === where.product_code && a.status === where.status),
+      update: async ({ where, data }) => {
+        const acc = store.accounts.find((a) => a.id === where.id && a.status === where.status);
+        if (!acc) throw new Error('Stok habis');
+        Object.assign(acc, data);
+        return acc;
+      },
+    },
+    orders: {
+      findUnique: async ({ where }) => store.orders.find((o) => o.id === where.id),
+      update: async ({ where, data }) => {
+        const o = store.orders.find((x) => x.id === where.id);
+        Object.assign(o, data);
+        return o;
+      },
+    },
+  }),
+} };
+
+require.cache[eventPath] = { exports: { addEvent: async () => {} } };
+
+const { reserveAccount } = require('../src/services/orders');
+
+test('reserveAccount allows only one reservation', async () => {
+  const [a, b] = await Promise.allSettled([reserveAccount(1), reserveAccount(2)]);
+  assert.strictEqual(a.status, 'fulfilled');
+  assert.strictEqual(b.status, 'rejected');
+});
+

--- a/test/transition.test.js
+++ b/test/transition.test.js
@@ -1,0 +1,11 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { detectTransition } = require('../src/services/worker');
+
+test('detectTransition flags stock changes', () => {
+  assert.strictEqual(detectTransition(true, false), 'OUT_OF_STOCK');
+  assert.strictEqual(detectTransition(false, true), 'RESTOCKED');
+  assert.strictEqual(detectTransition(true, true), null);
+});
+


### PR DESCRIPTION
## Summary
- sync subproduct configs from spreadsheet including pre-approval flags
- add pre-approval routes and Telegram callbacks with WhatsApp invoice send
- implement warranty claim lifecycle and stock transition alerts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba566043648329b430a9d8410db17c