### PR TITLE
feat: enhance WhatsApp stock, reservation, and warranty flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Jalankan seluruh tes unit:
 npm test
 ```
 
+## Contoh Alur WhatsApp
+
+Menu awal kini menampilkan tombol "🛡️ Klaim Garansi" bersama menu lain. Untuk memilih durasi produk dan melihat stok real-time gunakan perintah `durasi <kode>` yang akan menampilkan daftar seperti:
+
+```
+Durasi 30 hari – Stok: 5
+```
+
+Saat pembayaran dikonfirmasi, sistem akan memanggil `reserveAccount()` untuk mengunci stok agar tidak terjadi oversell.
+
 ## Integrasi n8n
 Backend dapat mengirim setiap event order ke workflow n8n sehingga otomatisasi bisa dilakukan tanpa mengubah kode.
 

--- a/test/reserve-flow.test.js
+++ b/test/reserve-flow.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+const eventPath = require.resolve('../src/services/events');
+const waPath = require.resolve('../src/services/wa');
+
+const store = {
+  accounts: [{ id:1, product_code:'P', status:'AVAILABLE' }],
+  orders: [
+    { id:1, invoice:'A', product_code:'P', buyer_phone:'1', product:{ delivery_mode:'sharing' } },
+    { id:2, invoice:'B', product_code:'P', buyer_phone:'2', product:{ delivery_mode:'sharing' } },
+  ],
+  messages: [],
+};
+
+require.cache[dbPath] = { exports: {
+  $transaction: async (fn) => fn({
+    accounts: {
+      findFirst: async ({ where }) => store.accounts.find(a=>a.product_code===where.product_code && a.status===where.status),
+      update: async ({ where, data }) => {
+        const acc = store.accounts.find(a=>a.id===where.id && a.status===where.status);
+        if(!acc) throw new Error('Stok habis');
+        Object.assign(acc,data); return acc;
+      },
+    },
+    orders: {
+      findUnique: async ({ where }) => store.orders.find(o=>o.id===where.id),
+      update: async ({ where, data }) => { const o=store.orders.find(x=>x.id===where.id); Object.assign(o,data); return o; },
+    },
+  }),
+  orders: {
+    findUnique: async ({ where }) => store.orders.find(o=>o.invoice===where.invoice),
+    update: async ({ where, data }) => { const o=store.orders.find(x=>x.invoice===where.invoice); Object.assign(o,data); return o; },
+  },
+  tasks: { create: async ()=>{} },
+} };
+
+require.cache[eventPath] = { exports: { addEvent: async () => {} } };
+require.cache[waPath] = { exports: { sendText: async (to,text)=>{ store.messages.push({to,text}); } } };
+
+const { confirmPaid } = require('../src/services/orders');
+
+test('only one confirmation succeeds reserving stock', async () => {
+  const [a,b] = await Promise.all([confirmPaid('A'), confirmPaid('B')]);
+  const failures = [a,b].filter(x=>!x.ok);
+  assert.strictEqual(failures.length,1);
+  assert.ok(store.messages[0].text.includes('Stok'));
+});

--- a/test/wa-claim-flow.test.js
+++ b/test/wa-claim-flow.test.js
@@ -1,0 +1,50 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.WA_APP_SECRET = '';
+const waPath = require.resolve('../src/services/wa');
+const claimPath = require.resolve('../src/services/claims');
+const dbPath = require.resolve('../src/db/client');
+const tgPath = require.resolve('../src/services/telegram');
+
+const messages = [];
+require.cache[waPath] = { exports: {
+  sendText: async (...args) => { messages.push({ type: 'text', args }); },
+  sendInteractiveButtons: async (...args) => { messages.push({ type: 'buttons', args }); },
+  sendListMenu: async () => {},
+} };
+require.cache[claimPath] = { exports: { createClaim: async (invoice, reason) => { messages.push({ type: 'claim', invoice, reason }); } } };
+require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
+require.cache[dbPath] = { exports: {
+  orders: {
+    findUnique: async ({ where }) => {
+      if (where.invoice !== 'INV-1') return null;
+      return { invoice: 'INV-1', status: 'DELIVERED', amount_cents: 10000, created_at: new Date(Date.now()-5*86400000), product:{ name:'Prod', duration_months:1 } };
+    },
+  },
+} };
+
+const waWebhook = require('../src/whatsapp/webhook');
+
+function startApp() {
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use('/', waWebhook);
+  return app;
+}
+
+test('claim flow triggers createClaim', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  function send(body){ return fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b4', title:'🛡️ Klaim Garansi' } } }] } }] }] });
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'INV-1' } }] } }] }] });
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b1', title:'Ajukan Klaim' } } }] } }] }] });
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'rusak' } }] } }] }] });
+  await new Promise(r=>server.close(r));
+  const claimCall = messages.find(m=>m.type==='claim');
+  assert.ok(claimCall);
+  assert.strictEqual(claimCall.invoice,'INV-1');
+  assert.strictEqual(claimCall.reason,'rusak');
+});

--- a/test/wa-stock.test.js
+++ b/test/wa-stock.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.WA_APP_SECRET = '';
+const waPath = require.resolve('../src/services/wa');
+const stockPath = require.resolve('../src/services/stock');
+const tgPath = require.resolve('../src/services/telegram');
+const orderPath = require.resolve('../src/services/orders');
+
+const listCalls = [];
+require.cache[waPath] = { exports: { sendText: async () => {}, sendInteractiveButtons: async () => {}, sendListMenu: async (...args) => { listCalls.push(args); } } };
+require.cache[stockPath] = { exports: { getStockOptions: async () => [ { durationDays: 30, stock: 2 }, { durationDays: 60, stock: 0 } ] } };
+require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
+require.cache[orderPath] = { exports: { createOrder: async () => ({}), setPayAck: async () => {} } };
+
+const waWebhook = require('../src/whatsapp/webhook');
+
+function startApp() {
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use('/', waWebhook);
+  return app;
+}
+
+test('durasi menu shows stock and hides zero', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  const body = { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'durasi PROD' } }] } }] }] };
+  await fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(body) });
+  assert.strictEqual(listCalls.length,1);
+  const sections = listCalls[0][3]; // sendListMenu(to, header, body, sections)
+  const rows = sections[0].rows;
+  assert.strictEqual(rows.length,1);
+  assert.ok(rows[0].desc.includes('Stok: 2'));
+  await new Promise((r)=>server.close(r));
+});


### PR DESCRIPTION
## Summary
- show WhatsApp duration list with real-time stock and warranty claim entry point
- reserve stock when confirming payment and emit pre-approval events to n8n
- add integration tests for stock menu, claim flow, and stock reservation races

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba5d35d85c8329aa768be0435bc374