### PR TITLE
Handle sub-product ordering and claim refunds

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Durasi 30 hari – Stok: 5
 
 Saat pembayaran dikonfirmasi, sistem akan memanggil `reserveAccount()` untuk mengunci stok agar tidak terjadi oversell.
 
+Flow baru:
+
+- WA: pilih produk → pilih durasi (cek stok) → tekan tombol **Beli 1**.
+- WA: klaim garansi → setelah admin approve, bot meminta nomor ShopeePay dan menunggu input.
+- Admin: pre-approval bisa diaktifkan per sub-produk (contoh `PROD:30`).
+
 ## Integrasi n8n
 Backend dapat mengirim setiap event order ke workflow n8n sehingga otomatisasi bisa dilakukan tanpa mengubah kode.
 
@@ -90,6 +96,20 @@ Event lain yang mungkin diterima:
 
 ```json
 { "product_code": "CHATGPT", "status": "OUT_OF_STOCK" }
+```
+
+Contoh skema `stockalerts` terbaru:
+
+```prisma
+model stockalerts {
+  id             String   @id @default(cuid())
+  product_code   String
+  sub_code       String
+  last_status    String
+  last_notified_at DateTime?
+
+  @@unique([product_code, sub_code])
+}
 ```
 
 ## Telegram Webhook

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -177,6 +177,7 @@ model orders {
   proof_id        String?
   proof_mime      String?
   synced_to_sheet Boolean     @default(false)
+  sub_code        String      @default("default")
 
   product products  @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
   account accounts? @relation("OrderAccount", fields: [account_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
@@ -219,12 +220,14 @@ model warrantyclaims {
 }
 
 model stockalerts {
-  id           Int      @id @default(autoincrement())
-  product_code String   @unique
-  in_stock     Boolean  @default(true)
-  updated_at   DateTime @updatedAt
-
+  id             String   @id @default(cuid())
+  product_code   String
+  sub_code       String
+  last_status    String
+  last_notified_at DateTime?
   product products @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Cascade)
+
+  @@unique([product_code, sub_code])
 }
 
 model events {

--- a/src/routes/claims.js
+++ b/src/routes/claims.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-const { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded } = require('../services/claims');
+const { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded, requestEwallet } = require('../services/claims');
+const { claimState } = require('../whatsapp/state');
 
 router.post('/', async (req, res) => {
   try {
@@ -43,6 +44,16 @@ router.post('/:id/ewallet', async (req, res) => {
 router.post('/:id/refunded', async (req, res) => {
   try {
     await markRefunded(Number(req.params.id));
+    res.json({ ok: true });
+  } catch (e) {
+    res.status(400).json({ ok: false, error: e.message });
+  }
+});
+
+router.post('/:id/request-ewallet', async (req, res) => {
+  try {
+    const { phone } = await requestEwallet(Number(req.params.id));
+    claimState.set(phone, { step: 'CLAIM_WAIT_EWALLET', claimId: Number(req.params.id) });
     res.json({ ok: true });
   } catch (e) {
     res.status(400).json({ ok: false, error: e.message });

--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -11,7 +11,7 @@ async function createOrder({ buyer_phone, product_code, qty=1, amount_cents, ema
   const cfg = await prisma.subproductconfigs.findUnique({ where:{ product_code_sub_code:{ product_code, sub_code } } });
   const requiresApproval = cfg?.approval_required;
   const status = requiresApproval ? 'AWAITING_PREAPPROVAL' : 'PENDING_PAYMENT';
-  const order = await prisma.orders.create({ data:{ invoice, buyer_phone, product_code, qty, amount_cents: toCents(amount_cents), status, email } });
+  const order = await prisma.orders.create({ data:{ invoice, buyer_phone, product_code, qty, amount_cents: toCents(amount_cents), status, email, sub_code } });
   await addEvent(order.id, 'ORDER_CREATED', `Order ${invoice} created`);
   if(requiresApproval){
     const pre = await prisma.preapprovalrequests.create({ data:{ order_id: order.id, sub_code } });

--- a/src/whatsapp/state.js
+++ b/src/whatsapp/state.js
@@ -1,0 +1,3 @@
+const claimState = new Map();
+const orderState = new Map();
+module.exports = { claimState, orderState };

--- a/test/preapproval.test.js
+++ b/test/preapproval.test.js
@@ -39,10 +39,12 @@ test('order requiring approval goes to AWAITING_PREAPPROVAL', async () => {
   assert.strictEqual(store.preapps.length, 1);
   assert.strictEqual(emitted.length, 1);
   assert.strictEqual(emitted[0][0], '/preapproval-pending');
+  assert.strictEqual(store.orders[0].sub_code, 'need');
 });
 
 test('order without approval goes to PENDING_PAYMENT', async () => {
   const o = await createOrder({ buyer_phone: '1', product_code: 'P', qty: 1, amount_cents: 100, sub_code: 'none' });
   assert.strictEqual(o.status, 'PENDING_PAYMENT');
+  assert.strictEqual(store.orders[1].sub_code, 'none');
 });
 

--- a/test/stock-sub-transition.test.js
+++ b/test/stock-sub-transition.test.js
@@ -1,0 +1,51 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const workerPath = require.resolve('../src/services/worker');
+const dbPath = require.resolve('../src/db/client');
+const notifyPath = require.resolve('../src/services/telegram');
+const n8nPath = require.resolve('../src/utils/n8n');
+
+delete require.cache[workerPath];
+
+const store = {
+  products: [{ code:'P', is_active:true }],
+  accounts: [{ product_code:'P', status:'AVAILABLE', variant_duration:30 }],
+  alerts: [
+    { product_code:'P', sub_code:'P:30', last_status:'IN_STOCK' },
+    { product_code:'P', sub_code:'P:60', last_status:'OUT_OF_STOCK' },
+  ],
+  events: [],
+};
+
+require.cache[dbPath] = { exports: {
+  products: { findMany: async () => store.products },
+  accounts: { findMany: async ({ where }) => store.accounts.filter(a=>a.product_code===where.product_code && a.status===where.status) },
+  stockalerts: {
+    findMany: async ({ where }) => store.alerts.filter(a=>a.product_code===where.product_code),
+    create: async ({ data }) => { store.alerts.push(data); return data; },
+    update: async ({ where, data }) => {
+      const idx = store.alerts.findIndex(a=>a.product_code===where.product_code_sub_code.product_code && a.sub_code===where.product_code_sub_code.sub_code);
+      store.alerts[idx] = { ...store.alerts[idx], ...data };
+      return store.alerts[idx];
+    },
+  },
+} };
+require.cache[notifyPath] = { exports: { notifyAdmin: async () => {}, notifyCritical: async () => {}, tgCall: async () => {} } };
+require.cache[n8nPath] = { exports: { emitToN8N: async (...args) => { store.events.push(args); }, sendToN8N: async () => {} } };
+
+const { stockTransitions } = require('../src/services/worker');
+
+test('stock transitions per sub product', async () => {
+  await stockTransitions();
+  assert.strictEqual(store.events.length,0);
+  store.accounts = [{ product_code:'P', status:'AVAILABLE', variant_duration:60 }];
+  await stockTransitions();
+  assert.strictEqual(store.events.length,2);
+  assert.strictEqual(store.events[0][1].status,'RESTOCKED');
+  assert.strictEqual(store.events[0][1].sub_code,'P:60');
+  assert.strictEqual(store.events[1][1].status,'OUT_OF_STOCK');
+  assert.strictEqual(store.events[1][1].sub_code,'P:30');
+  await stockTransitions();
+  assert.strictEqual(store.events.length,2);
+});

--- a/test/wa-claim-ewallet.test.js
+++ b/test/wa-claim-ewallet.test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.WA_APP_SECRET = '';
+const waPath = require.resolve('../src/services/wa');
+const claimSvcPath = require.resolve('../src/services/claims');
+const dbPath = require.resolve('../src/db/client');
+const tgPath = require.resolve('../src/services/telegram');
+
+const messages = [];
+const ewalletCalls = [];
+require.cache[waPath] = { exports: {
+  sendText: async (...args) => { messages.push(args); },
+  sendInteractiveButtons: async () => {},
+  sendListMenu: async () => {},
+} };
+require.cache[claimSvcPath] = { exports: {
+  createClaim: async () => {},
+  approveClaim: async () => {},
+  rejectClaim: async () => {},
+  setEwallet: async (id, ew) => { ewalletCalls.push({ id, ew }); },
+  markRefunded: async () => {},
+  requestEwallet: async () => { await require.cache[waPath].exports.sendText('1','msg'); return { phone: '1' }; },
+} };
+require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
+require.cache[dbPath] = { exports: {
+  warrantyclaims: {
+    findUnique: async () => ({ id:1, refund_cents:5000, order:{ buyer_phone:'1' } }),
+    update: async () => ({}),
+  },
+} };
+
+const waWebhook = require('../src/whatsapp/webhook');
+const claimsRoute = require('../src/routes/claims');
+const { claimState } = require('../src/whatsapp/state');
+
+function startApp(){
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use('/claims', claimsRoute);
+  app.use('/', waWebhook);
+  return app;
+}
+
+test('claim approval asks for ewallet and stores number', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  function send(path, body){ return fetch(`http://127.0.0.1:${port}${path}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
+  await send('/claims/1/request-ewallet', {});
+  assert.strictEqual(messages.length,1);
+  assert.ok(claimState.has('1'));
+  await send('/', { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'0812345678' } }] } }] }] });
+  assert.strictEqual(ewalletCalls.length,1);
+  assert.strictEqual(ewalletCalls[0].ew,'0812345678');
+  assert.strictEqual(messages.length,2);
+  await new Promise(r=>server.close(r));
+});

--- a/test/wa-claim-flow.test.js
+++ b/test/wa-claim-flow.test.js
@@ -14,7 +14,7 @@ require.cache[waPath] = { exports: {
   sendInteractiveButtons: async (...args) => { messages.push({ type: 'buttons', args }); },
   sendListMenu: async () => {},
 } };
-require.cache[claimPath] = { exports: { createClaim: async (invoice, reason) => { messages.push({ type: 'claim', invoice, reason }); } } };
+require.cache[claimPath] = { exports: { createClaim: async (invoice, reason) => { messages.push({ type: 'claim', invoice, reason }); }, setEwallet: async () => {} } };
 require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
 require.cache[dbPath] = { exports: {
   orders: {

--- a/test/wa-duration-buy.test.js
+++ b/test/wa-duration-buy.test.js
@@ -1,0 +1,48 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.WA_APP_SECRET = '';
+const waPath = require.resolve('../src/services/wa');
+const orderPath = require.resolve('../src/services/orders');
+const dbPath = require.resolve('../src/db/client');
+const tgPath = require.resolve('../src/services/telegram');
+
+const buttons = [];
+const orders = [];
+require.cache[waPath] = { exports: {
+  sendText: async () => {},
+  sendInteractiveButtons: async (...args) => { buttons.push(args); },
+  sendListMenu: async () => {},
+  sendImageById: async () => {},
+  sendImageByUrl: async () => {},
+} };
+require.cache[orderPath] = { exports: {
+  createOrder: async (data) => { orders.push(data); return { invoice:'INV', status:'PENDING_PAYMENT', created_at:new Date() }; },
+  setPayAck: async () => {}
+} };
+require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
+require.cache[dbPath] = { exports: {
+  products: { findUnique: async () => ({ price_cents:1000, is_active:true }) },
+} };
+
+const waWebhook = require('../src/whatsapp/webhook');
+
+function startApp(){
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use('/', waWebhook);
+  return app;
+}
+
+test('select duration then buy creates order with sub_code', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  function send(body){ return fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ list_reply:{ id:'dur:PROD:30' } } }] } }] }] });
+  assert.strictEqual(buttons.length,1);
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b1', title:'Beli 1' } } }] } }] }] });
+  assert.strictEqual(orders.length,1);
+  assert.strictEqual(orders[0].sub_code,'PROD:30');
+  await new Promise(r=>server.close(r));
+});


### PR DESCRIPTION
## Summary
- Track sub-product codes when choosing duration and allow quick purchase via WhatsApp buttons
- Require and record e-wallet numbers for approved warranty claims
- Notify stock transitions per sub-product and persist last status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba63a1b95483298be51884fd5702c4