### PR TITLE
feat: normalize ShopeePay and guard idempotent decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ Flow baru:
 - WA: klaim garansi → setelah admin approve, bot meminta nomor ShopeePay dan menunggu input.
 - Admin: pre-approval bisa diaktifkan per sub-produk (contoh `PROD:30`).
 
+### Normalisasi ShopeePay
+
+- Nomor ShopeePay dinormalisasi sebelum disimpan: spasi/dash dihapus, hanya 10–15 digit dan harus diawali `08`.
+- Contoh: input `" 08-123 456 789 0 "` → disimpan dan ditampilkan kembali sebagai `081234567890`.
+- Jika format salah, bot membalas: `Format ShopeePay tidak valid. Kirim nomor 10–15 digit diawali 08 (contoh 081234567890).`
+ - Contoh balasan sukses: `Nomor ShopeePay diterima: 081234567890. Refund diproses maksimal 2×24 jam.`
+
+### Idempotensi Ekstra
+
+- Endpoint pre-approval (`approve`/`reject`) dan klaim (`approve`/`reject`/`ewallet`/`refunded`) aman dari double-tap.
+- Jika status sudah final, panggilan ulang mengembalikan `200` dengan `{ idempotent: true }` tanpa efek samping.
+
 ## Integrasi n8n
 Backend dapat mengirim setiap event order ke workflow n8n sehingga otomatisasi bisa dilakukan tanpa mengubah kode.
 

--- a/src/routes/claims.js
+++ b/src/routes/claims.js
@@ -16,8 +16,9 @@ router.post('/', async (req, res) => {
 
 router.post('/:id/approve', async (req, res) => {
   try {
-    await approveClaim(Number(req.params.id));
-    res.json({ ok: true });
+    const r = await approveClaim(Number(req.params.id));
+    if (r.idempotent) return res.json(r);
+    res.json({ ok: true, ...r });
   } catch (e) {
     res.status(400).json({ ok: false, error: e.message });
   }
@@ -25,8 +26,9 @@ router.post('/:id/approve', async (req, res) => {
 
 router.post('/:id/reject', async (req, res) => {
   try {
-    await rejectClaim(Number(req.params.id), req.body?.reason);
-    res.json({ ok: true });
+    const r = await rejectClaim(Number(req.params.id), req.body?.reason);
+    if (r.idempotent) return res.json(r);
+    res.json({ ok: true, ...r });
   } catch (e) {
     res.status(400).json({ ok: false, error: e.message });
   }
@@ -34,8 +36,9 @@ router.post('/:id/reject', async (req, res) => {
 
 router.post('/:id/ewallet', async (req, res) => {
   try {
-    await setEwallet(Number(req.params.id), req.body?.ewallet);
-    res.json({ ok: true });
+    const r = await setEwallet(Number(req.params.id), req.body?.ewallet);
+    if (r.idempotent) return res.json(r);
+    res.json({ ok: true, ...r });
   } catch (e) {
     res.status(400).json({ ok: false, error: e.message });
   }
@@ -43,8 +46,9 @@ router.post('/:id/ewallet', async (req, res) => {
 
 router.post('/:id/refunded', async (req, res) => {
   try {
-    await markRefunded(Number(req.params.id));
-    res.json({ ok: true });
+    const r = await markRefunded(Number(req.params.id));
+    if (r.idempotent) return res.json(r);
+    res.json({ ok: true, ...r });
   } catch (e) {
     res.status(400).json({ ok: false, error: e.message });
   }

--- a/src/routes/preapprovals.js
+++ b/src/routes/preapprovals.js
@@ -11,6 +11,7 @@ router.post('/:id/approve', async (req, res) => {
     const invoice = req.params.id;
     const r = await approvePreapproval(invoice);
     if (!r.ok) return res.status(400).json(r);
+    if (r.idempotent) return res.json(r);
 
     const order = await prisma.orders.findUnique({ where: { invoice } });
     if (!order) return res.status(404).json({ ok: false, error: 'ORDER_NOT_FOUND' });
@@ -32,6 +33,7 @@ router.post('/:id/reject', async (req, res) => {
     const reason = req.body?.reason;
     const r = await rejectPreapproval(invoice, reason);
     if (!r.ok) return res.status(400).json(r);
+    if (r.idempotent) return res.json(r);
 
     const order = await prisma.orders.findUnique({ where: { invoice }, include: { preapproval: true } });
     if (order) {

--- a/src/services/claims.js
+++ b/src/services/claims.js
@@ -3,6 +3,7 @@ const { calcLinearRefund } = require('../utils/refund');
 const { emitToN8N } = require('../utils/n8n');
 const { appendWarrantyLog } = require('./sheet');
 const { sendText } = require('./wa');
+const { normalizeEwallet } = require('../utils/validation');
 
 async function createClaim(invoice, reason) {
   const order = await prisma.orders.findUnique({ where: { invoice }, include: { product: true } });
@@ -15,32 +16,58 @@ async function createClaim(invoice, reason) {
 async function approveClaim(id) {
   const claim = await prisma.warrantyclaims.findUnique({ where: { id }, include: { order: { include: { product: true } } } });
   if (!claim) throw new Error('CLAIM_NOT_FOUND');
+  if (['REJECTED', 'REFUNDED'].includes(claim.status)) {
+    console.log({ idempotent_noop: true, action: 'claim.approve', id, status: claim.status });
+    return { ok: true, idempotent: true, message: 'claim already finalized', status: claim.status };
+  }
   const order = claim.order;
   const warrantyDays = (order.product.duration_months || 0) * 30;
   const usedDays = Math.floor((Date.now() - order.created_at.getTime()) / 86400000);
   const refund = calcLinearRefund({ priceCents: order.amount_cents, warrantyDays, usedDays });
   const upd = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'APPROVED', refund_cents: refund } });
   await emitToN8N('/claim-approved', { id, refund_cents: refund });
-  return upd;
+  return { ok: true, claim: upd };
 }
 
 async function rejectClaim(id, reason) {
+  const claim = await prisma.warrantyclaims.findUnique({ where: { id } });
+  if (!claim) throw new Error('CLAIM_NOT_FOUND');
+  if (['REJECTED', 'REFUNDED'].includes(claim.status)) {
+    console.log({ idempotent_noop: true, action: 'claim.reject', id, status: claim.status });
+    return { ok: true, idempotent: true, message: 'claim already finalized', status: claim.status };
+  }
   const upd = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'REJECTED', reason } });
   await emitToN8N('/claim-rejected', { id, reason });
-  return upd;
+  return { ok: true, claim: upd };
 }
 
 async function setEwallet(id, ewallet) {
-  return prisma.warrantyclaims.update({ where: { id }, data: { ewallet, status: 'AWAITING_REFUND' } });
+  const claim = await prisma.warrantyclaims.findUnique({ where: { id } });
+  if (!claim) throw new Error('CLAIM_NOT_FOUND');
+  if (['REJECTED', 'REFUNDED'].includes(claim.status)) {
+    console.log({ idempotent_noop: true, action: 'claim.ewallet', id, status: claim.status });
+    return { ok: true, idempotent: true, message: 'claim already finalized', status: claim.status };
+  }
+  const { normalized, isValid } = normalizeEwallet(ewallet || '');
+  if (!isValid) throw new Error('INVALID_EWALLET');
+  if (claim.ewallet === normalized) {
+    return { ok: true, idempotent: true, status: claim.status };
+  }
+  const upd = await prisma.warrantyclaims.update({ where: { id }, data: { ewallet: normalized, status: 'AWAITING_REFUND' } });
+  return { ok: true, claim: upd };
 }
 
 async function markRefunded(id) {
-  const claim = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'REFUNDED' }, include: { order: true } });
-  await appendWarrantyLog({ claimId: id, invoice: claim.order.invoice, refund_cents: claim.refund_cents, ewallet: claim.ewallet });
-  return claim;
+  const claim = await prisma.warrantyclaims.findUnique({ where: { id }, include: { order: true } });
+  if (!claim) throw new Error('CLAIM_NOT_FOUND');
+  if (['REJECTED', 'REFUNDED'].includes(claim.status)) {
+    console.log({ idempotent_noop: true, action: 'claim.refunded', id, status: claim.status });
+    return { ok: true, idempotent: true, message: 'claim already finalized', status: claim.status };
+  }
+  const upd = await prisma.warrantyclaims.update({ where: { id }, data: { status: 'REFUNDED' }, include: { order: true } });
+  await appendWarrantyLog({ claimId: id, invoice: upd.order.invoice, refund_cents: upd.refund_cents, ewallet: upd.ewallet });
+  return { ok: true, claim: upd };
 }
-
-module.exports = { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded };
 
 async function requestEwallet(id) {
   const claim = await prisma.warrantyclaims.findUnique({ where: { id }, include: { order: true } });
@@ -51,5 +78,5 @@ async function requestEwallet(id) {
   return { phone };
 }
 
+module.exports = { createClaim, approveClaim, rejectClaim, setEwallet, markRefunded };
 module.exports.requestEwallet = requestEwallet;
-

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,17 @@
+function normalizeEwallet(msisdn) {
+  if (typeof msisdn !== 'string') {
+    return { normalized: '', isValid: false, reason: 'not_string' };
+  }
+  const cleaned = msisdn.trim().replace(/[\s-]+/g, '');
+  const isDigits = /^\d+$/.test(cleaned);
+  const okPrefix = cleaned.startsWith('08');
+  const okLength = cleaned.length >= 10 && cleaned.length <= 15;
+  const isValid = isDigits && okPrefix && okLength;
+  let reason = '';
+  if (!isDigits) reason = 'non_digit';
+  else if (!okPrefix) reason = 'invalid_prefix';
+  else if (!okLength) reason = 'invalid_length';
+  return { normalized: cleaned, isValid, reason };
+}
+
+module.exports = { normalizeEwallet };

--- a/test/claim-idempotent.test.js
+++ b/test/claim-idempotent.test.js
@@ -1,0 +1,66 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.TELEGRAM_BOT_TOKEN = 'x';
+process.env.ADMIN_CHAT_ID = '1';
+process.env.WEBHOOK_SECRET_PATH = 's';
+process.env.DATABASE_URL = 'postgres://x';
+process.env.ENCRYPTION_KEY = Buffer.alloc(32).toString('base64');
+
+const dbPath = require.resolve('../src/db/client');
+const waPath = require.resolve('../src/services/wa');
+const sheetPath = require.resolve('../src/services/sheet');
+const n8nPath = require.resolve('../src/utils/n8n');
+
+let updateCount = 0;
+const logs = [];
+require.cache[waPath] = { exports: { sendText: async () => {} } };
+require.cache[sheetPath] = { exports: { appendWarrantyLog: async (...args) => { logs.push(args); } } };
+require.cache[n8nPath] = { exports: { emitToN8N: async () => {} } };
+
+const store = { claim: { id:1, status:'REFUNDED', ewallet:'0812345678', refund_cents:1000, order:{ invoice:'INV1', buyer_phone:'1' } } };
+require.cache[dbPath] = { exports: {
+  warrantyclaims: {
+    findUnique: async ({ where, include }) => {
+      if (where.id !== 1) return null;
+      const c = { ...store.claim };
+      if (include?.order) c.order = store.claim.order;
+      return c;
+    },
+    update: async ({ data }) => { updateCount++; Object.assign(store.claim, data); return { ...store.claim, order: store.claim.order }; }
+  }
+} };
+
+const claimsRoute = require('../src/routes/claims');
+
+function start(){ const app=express(); app.use(express.json()); app.use('/claims', claimsRoute); return app; }
+
+test('claim endpoints idempotent after refund', async () => {
+  const app = start();
+  const server = app.listen(0); const port = server.address().port;
+  const send = (path, body) => fetch(`http://127.0.0.1:${port}${path}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body||{}) });
+
+  let res = await send('/claims/1/approve');
+  let body = await res.json();
+  assert.ok(body.idempotent);
+  assert.strictEqual(updateCount,0);
+
+  res = await send('/claims/1/reject', { reason:'x' });
+  body = await res.json();
+  assert.ok(body.idempotent);
+  assert.strictEqual(updateCount,0);
+
+  res = await send('/claims/1/ewallet', { ewallet:'0812345678' });
+  body = await res.json();
+  assert.ok(body.idempotent);
+  assert.strictEqual(updateCount,0);
+
+  res = await send('/claims/1/refunded');
+  body = await res.json();
+  assert.ok(body.idempotent);
+  assert.strictEqual(updateCount,0);
+  assert.strictEqual(logs.length,0);
+
+  await new Promise(r=>server.close(r));
+});

--- a/test/claim.test.js
+++ b/test/claim.test.js
@@ -41,7 +41,7 @@ const { calcLinearRefund } = require('../src/utils/refund');
 test('approveClaim calculates prorated refund', async () => {
   const r = await approveClaim(1);
   const expected = calcLinearRefund({ priceCents: order.amount_cents, warrantyDays: 300, usedDays: 5 });
-  assert.strictEqual(r.refund_cents, expected);
-  assert.strictEqual(r.status, 'APPROVED');
+  assert.strictEqual(r.claim.refund_cents, expected);
+  assert.strictEqual(r.claim.status, 'APPROVED');
 });
 

--- a/test/ewallet-normalize.test.js
+++ b/test/ewallet-normalize.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const { normalizeEwallet } = require('../src/utils/validation');
+
+test('normalize valid ewallet number', () => {
+  const r = normalizeEwallet(' 08-123 456 789 0 ');
+  assert.strictEqual(r.normalized, '081234567890');
+  assert.ok(r.isValid);
+});
+
+test('reject too short', () => {
+  const r = normalizeEwallet('08123');
+  assert.ok(!r.isValid);
+});
+
+test('reject wrong prefix', () => {
+  const r = normalizeEwallet('0712345678');
+  assert.ok(!r.isValid);
+});
+
+test('reject too long', () => {
+  const r = normalizeEwallet('0812345678901234');
+  assert.ok(!r.isValid);
+});

--- a/test/preapproval-idempotent.test.js
+++ b/test/preapproval-idempotent.test.js
@@ -1,0 +1,63 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+
+process.env.TELEGRAM_BOT_TOKEN = 'x';
+process.env.ADMIN_CHAT_ID = '1';
+process.env.WEBHOOK_SECRET_PATH = 's';
+process.env.DATABASE_URL = 'postgres://x';
+process.env.ENCRYPTION_KEY = Buffer.alloc(32).toString('base64');
+
+const messages = [];
+const waPath = require.resolve('../src/services/wa');
+const eventPath = require.resolve('../src/services/events');
+require.cache[waPath] = { exports: {
+  sendText: async (...args) => { messages.push(args); },
+  sendImageById: async (...args) => { messages.push(args); },
+  sendImageByUrl: async (...args) => { messages.push(args); },
+} };
+require.cache[eventPath] = { exports: { addEvent: async () => {} } };
+
+const dbPath = require.resolve('../src/db/client');
+const store = { order: { id:1, invoice:'INV1', buyer_phone:'1', amount_cents:1000, created_at:new Date(), status:'AWAITING_PREAPPROVAL', preapproval:{ status:'PENDING', sub_code:'default' } } };
+require.cache[dbPath] = { exports: {
+  orders: {
+    findUnique: async ({ where, include }) => {
+      if (where.invoice !== 'INV1') return null;
+      const o = { ...store.order };
+      if (include?.preapproval) o.preapproval = store.order.preapproval;
+      return o;
+    },
+    update: async ({ data }) => { Object.assign(store.order, data); return store.order; }
+  },
+  preapprovalrequests: {
+    update: async ({ data }) => { Object.assign(store.order.preapproval, data); return store.order.preapproval; }
+  },
+  $transaction: async (ops) => { for (const op of ops) await op; }
+} };
+
+const preRoute = require('../src/routes/preapprovals');
+
+function start(){ const app=express(); app.use(express.json()); app.use('/preapprovals', preRoute); return app; }
+
+test('preapproval approve/reject idempotent', async () => {
+  const app = start();
+  const server = app.listen(0); const port = server.address().port;
+  const send = (path, body) => fetch(`http://127.0.0.1:${port}${path}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body||{}) });
+
+  let res = await send('/preapprovals/INV1/approve');
+  assert.strictEqual(store.order.preapproval.status, 'APPROVED');
+  assert.strictEqual(messages.length,1);
+
+  res = await send('/preapprovals/INV1/approve');
+  const body = await res.json();
+  assert.ok(body.idempotent);
+  assert.strictEqual(messages.length,1);
+
+  res = await send('/preapprovals/INV1/reject', { reason:'x' });
+  const body2 = await res.json();
+  assert.ok(body2.idempotent);
+  assert.strictEqual(messages.length,1);
+
+  await new Promise(r=>server.close(r));
+});

--- a/test/wa-claim-ewallet.test.js
+++ b/test/wa-claim-ewallet.test.js
@@ -50,9 +50,10 @@ test('claim approval asks for ewallet and stores number', async () => {
   await send('/claims/1/request-ewallet', {});
   assert.strictEqual(messages.length,1);
   assert.ok(claimState.has('1'));
-  await send('/', { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'0812345678' } }] } }] }] });
+  await send('/', { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:' 08-123 456 789 0 ' } }] } }] }] });
   assert.strictEqual(ewalletCalls.length,1);
-  assert.strictEqual(ewalletCalls[0].ew,'0812345678');
+  assert.strictEqual(ewalletCalls[0].ew,'081234567890');
   assert.strictEqual(messages.length,2);
+  assert.strictEqual(messages[1][1],'Nomor ShopeePay diterima: 081234567890. Refund diproses maksimal 2×24 jam.');
   await new Promise(r=>server.close(r));
 });


### PR DESCRIPTION
## Summary
- sanitize ShopeePay numbers and validate prefix/length
- guard pre-approval and claim endpoints with idempotent status checks
- document normalization & double-tap safety

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6ba0fdcc8329806c1247daa17a7a