### PR TITLE
feat: add help request status

### DIFF
--- a/prisma/migrations/20240907000000_add_help_fields/migration.sql
+++ b/prisma/migrations/20240907000000_add_help_fields/migration.sql
@@ -1,0 +1,10 @@
+-- Alter OrderStatus to add ON_HOLD_HELP
+ALTER TYPE "OrderStatus" ADD VALUE IF NOT EXISTS 'ON_HOLD_HELP';
+
+-- Add fulfillment timestamps to orders
+ALTER TABLE "orders" ADD COLUMN "fulfilled_at" TIMESTAMP(3), ADD COLUMN "expires_at" TIMESTAMP(3);
+
+-- Add help related events
+ALTER TYPE "EventKind" ADD VALUE IF NOT EXISTS 'HELP_REQUESTED';
+ALTER TYPE "EventKind" ADD VALUE IF NOT EXISTS 'HELP_RESUMED';
+ALTER TYPE "EventKind" ADD VALUE IF NOT EXISTS 'HELP_CANCELLED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ enum OrderStatus {
   REFUND_APPROVED
   REFUND_REJECTED
   AWAITING_PREAPPROVAL
+  ON_HOLD_HELP
 }
 
 enum DeliveryMode {
@@ -61,6 +62,9 @@ enum EventKind {
   SHEET_SYNC_FAIL
   RATE_LIMITED
   DEAD_LETTER_STORED
+  HELP_REQUESTED
+  HELP_RESUMED
+  HELP_CANCELLED
 }
 
 enum Actor {
@@ -113,12 +117,13 @@ model products {
   daily_limit     Int?
   sk_text         String?
 
-  accounts accounts[]
-  orders   orders[]
+  accounts   accounts[]
+  orders     orders[]
   subconfigs subproductconfigs[]
 
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
+  created_at  DateTime      @default(now())
+  updated_at  DateTime      @updatedAt
+  stockalerts stockalerts[]
 }
 
 model accounts {
@@ -149,10 +154,10 @@ model accounts {
 }
 
 model subproductconfigs {
-  id                   Int      @id @default(autoincrement())
-  product_code         String
-  sub_code             String
-  approval_required    Boolean  @default(false)
+  id                     Int     @id @default(autoincrement())
+  product_code           String
+  sub_code               String
+  approval_required      Boolean @default(false)
   approval_notes_default String?
 
   product products @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Cascade)
@@ -174,19 +179,22 @@ model orders {
   email           String?
   account_id      Int?
   pay_ack_at      DateTime?
+  fulfilled_at    DateTime?
+  expires_at      DateTime?
   proof_id        String?
   proof_mime      String?
   synced_to_sheet Boolean     @default(false)
   sub_code        String      @default("default")
 
-  product products  @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
-  account accounts? @relation("OrderAccount", fields: [account_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
-  events  events[]
-  tasks   tasks[]
+  product     products             @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Restrict)
+  account     accounts?            @relation("OrderAccount", fields: [account_id], references: [id], onUpdate: Cascade, onDelete: SetNull)
+  events      events[]
+  tasks       tasks[]
   preapproval preapprovalrequests?
 
-  created_at DateTime @default(now())
-  updated_at DateTime @updatedAt
+  created_at     DateTime        @default(now())
+  updated_at     DateTime        @updatedAt
+  warrantyclaims warrantyclaims?
 
   @@index([status])
   @@index([product_code, created_at])
@@ -194,11 +202,11 @@ model orders {
 }
 
 model preapprovalrequests {
-  id        Int              @id @default(autoincrement())
-  order_id  BigInt           @unique
-  status    PreapprovalStatus @default(PENDING)
-  notes     String?
-  sub_code  String?
+  id       Int               @id @default(autoincrement())
+  order_id BigInt            @unique
+  status   PreapprovalStatus @default(PENDING)
+  notes    String?
+  sub_code String?
 
   order orders @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
 
@@ -207,25 +215,25 @@ model preapprovalrequests {
 }
 
 model warrantyclaims {
-  id          BigInt     @id @default(autoincrement())
-  order_id    BigInt     @unique
-  status      ClaimStatus @default(PENDING)
-  reason      String?
+  id           BigInt      @id @default(autoincrement())
+  order_id     BigInt      @unique
+  status       ClaimStatus @default(PENDING)
+  reason       String?
   refund_cents Int?
-  ewallet     String?
-  created_at  DateTime   @default(now())
-  updated_at  DateTime   @updatedAt
+  ewallet      String?
+  created_at   DateTime    @default(now())
+  updated_at   DateTime    @updatedAt
 
   order orders @relation(fields: [order_id], references: [id], onUpdate: Cascade, onDelete: Cascade)
 }
 
 model stockalerts {
-  id             String   @id @default(cuid())
-  product_code   String
-  sub_code       String
-  last_status    String
+  id               String    @id @default(cuid())
+  product_code     String
+  sub_code         String
+  last_status      String
   last_notified_at DateTime?
-  product products @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Cascade)
+  product          products  @relation(fields: [product_code], references: [code], onUpdate: Cascade, onDelete: Cascade)
 
   @@unique([product_code, sub_code])
 }

--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -116,4 +116,10 @@ async function markInvited(invoice){
   return { ok:true };
 }
 
-module.exports = { createOrder, setPayAck, confirmPaid, rejectOrder, markInvited, approvePreapproval, rejectPreapproval, reserveAccount };
+async function requestHelp(orderId){
+  const o = await prisma.orders.update({ where:{ id: orderId }, data:{ status:'ON_HOLD_HELP' } });
+  await addEvent(o.id, 'HELP_REQUESTED', 'Customer requested help');
+  return o;
+}
+
+module.exports = { createOrder, setPayAck, confirmPaid, rejectOrder, markInvited, approvePreapproval, rejectPreapproval, reserveAccount, requestHelp };

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -1,0 +1,24 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+const eventPath = require.resolve('../src/services/events');
+
+const store = { orders: [{ id: 1, status: 'PENDING_PAYMENT' }] };
+
+require.cache[dbPath] = { exports: { orders: { update: async ({ where, data }) => {
+  const o = store.orders.find(x => x.id === where.id);
+  Object.assign(o, data);
+  return o;
+}} } };
+
+const events = [];
+require.cache[eventPath] = { exports: { addEvent: async (orderId, kind) => { events.push({ orderId, kind }); } } };
+
+const { requestHelp } = require('../src/services/orders');
+
+test('requestHelp switches status and logs event', async () => {
+  await requestHelp(1);
+  assert.strictEqual(store.orders[0].status, 'ON_HOLD_HELP');
+  assert.deepStrictEqual(events, [{ orderId: 1, kind: 'HELP_REQUESTED' }]);
+});


### PR DESCRIPTION
## Summary
- add `ON_HOLD_HELP` status and help-related event kinds
- track fulfillment timestamps on orders
- add requestHelp service and tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bab6f528148329b336acaf90a08fd8