### PR TITLE
feat: low stock alerts and help notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ model stockalerts {
 }
 ```
 
+## n8n flows
+
+Selain event real-time, backend menyediakan beberapa alur khusus untuk integrasi spreadsheet via n8n:
+
+- `POST /tx-append` akan menambahkan baris baru ke tab **TRANSACTIONS**.
+- Pekerja berkala memanggil flow untuk menyinkronkan ringkasan:
+  - **AKTIF** → order dengan `expires_at >= now`
+  - **BERAKHIR** → order dengan `expires_at < now`
+
+Contoh payload yang dikirim ke `/tx-append`:
+
+```json
+{
+  "ts": "2024-01-01T00:00:00.000Z",
+  "invoice": "INV-123",
+  "buyer": "628123456789",
+  "code": "PROD30",
+  "variant_id": "uuid-v1",
+  "order_status": "DELIVERED",
+  "fulfilled_at": "2024-01-01T00:00:00.000Z",
+  "expires_at": "2024-01-31T00:00:00.000Z",
+  "account_id": 1,
+  "channel": "WA"
+}
+```
+
 ## Telegram Webhook
 Pastikan domain sudah HTTPS, kemudian set webhook:
 ```bash

--- a/src/services/telegram.js
+++ b/src/services/telegram.js
@@ -27,6 +27,15 @@ function answerCallbackQuery(id, text='', extra={}){ return tgCall('answerCallba
 async function notifyAdmin(text){ try{ await sendMessage(ADMIN_CHAT_ID, text, { parse_mode:'HTML' }); }catch(_){} }
 async function notifyCritical(text){ await notifyAdmin('⚠️ <b>CRITICAL</b>\n'+text); }
 
+async function notifyHelpRequested(orderId, stageCtx){
+  const kb = { reply_markup:{ inline_keyboard:[
+    [{text:'▶️ Resume', callback_data:`HELP_RESUME:${orderId}`}],
+    [{text:'⏭ Skip → PAID', callback_data:`HELP_SKIP:${orderId}:PAID`}],
+    [{text:'❌ Cancel', callback_data:`HELP_CANCEL:${orderId}`}],
+  ] } };
+  await sendMessage(ADMIN_CHAT_ID, `🆘 HELP_REQUESTED #${orderId}\n<code>${JSON.stringify(stageCtx)}</code>`, { parse_mode:'HTML', ...kb });
+}
+
 function buildOrderKeyboard(invoice, productMode){
   const rows=[];
   rows.push([{text:'✅ Konfirmasi',callback_data:`confirm:${invoice}`},{text:'❌ Tolak',callback_data:`reject:${invoice}`}]);
@@ -55,4 +64,4 @@ function buildGrid(items=[], cols=3, mapFn=it=>({ text: it.label, data: it.id })
   return { reply_markup:{ inline_keyboard: rows } };
 }
 
-module.exports = { sendMessage, editMessageText, answerCallbackQuery, notifyAdmin, notifyCritical, buildOrderKeyboard, buildNumberGrid, buildGrid, tgCall };
+module.exports = { sendMessage, editMessageText, answerCallbackQuery, notifyAdmin, notifyCritical, notifyHelpRequested, buildOrderKeyboard, buildNumberGrid, buildGrid, tgCall };

--- a/test/low-stock-alert.test.js
+++ b/test/low-stock-alert.test.js
@@ -1,0 +1,23 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const stockPath = require.resolve('../src/services/stock');
+const eventPath = require.resolve('../src/services/events');
+const tgPath = require.resolve('../src/services/telegram');
+const dbPath = require.resolve('../src/db/client');
+
+require.cache[stockPath] = { exports:{ getStockSummaryRaw: async () => ([{ code:'A', variant_id:'v1', units:1, capacity:2 }]) } };
+const events = [];
+require.cache[eventPath] = { exports:{ addEvent: async (...args) => { events.push(args); return {}; } } };
+const notes = [];
+require.cache[tgPath] = { exports:{ notifyAdmin: async (txt) => { notes.push(txt); } } };
+require.cache[dbPath] = { exports:{ thresholds:{ findMany: async () => ([{ variant_id:'v1', low_stock_units:2, low_stock_capacity:3 }]) } } };
+
+delete require.cache[require.resolve('../src/services/worker')];
+const { lowStockAlert } = require('../src/services/worker');
+
+test('lowStockAlert triggers when below threshold', async () => {
+  await lowStockAlert();
+  assert.strictEqual(events.length,1);
+  assert.strictEqual(notes.length,1);
+});

--- a/test/reserve-flow.test.js
+++ b/test/reserve-flow.test.js
@@ -67,7 +67,7 @@ test('only one confirmation succeeds reserving stock', async () => {
 test('fallback by product_code and auto-disable when max usage reached', async () => {
   store.accounts = [{ id:2, variant_id:null, product_code:'X', status:'AVAILABLE', max_usage:1, used_count:0, fifo_order:1n, natural_key:'k2' }];
   store.orders.push({ id:3, invoice:'C', product_code:'X', buyer_phone:'3', product:{ delivery_mode:'sharing', duration_months:1 }, delivery_mode:'USERPASS' });
-  require.cache[variantPath].exports.resolveVariantByCode = async () => null;
+  require.cache[variantPath].exports.resolveVariantByCode = async () => { throw new Error('should not call'); };
   delete require.cache[require.resolve('../src/services/orders')];
   const { confirmPaid: confirmPaid2 } = require('../src/services/orders');
   await confirmPaid2('C');

--- a/test/sheet.test.js
+++ b/test/sheet.test.js
@@ -1,6 +1,8 @@
 const assert = require('node:assert');
 const { test } = require('node:test');
 
+const dbPath = require.resolve('../src/db/client');
+require.cache[dbPath] = { exports:{} };
 const { parseApprovalRequired } = require('../src/services/sheet');
 
 test('parseApprovalRequired only accepts exact "On"', () => {

--- a/test/stock-detail.test.js
+++ b/test/stock-detail.test.js
@@ -1,0 +1,17 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+require.cache[dbPath] = { exports:{ $queryRaw: async (strings,...vals) => {
+  const sql = strings.join('?');
+  assert.ok(!/password/i.test(sql));
+  return [{ id:1, fifo_order:0, used_count:0, max_usage:1, status:'AVAILABLE' }];
+} } };
+
+const { getStockDetail } = require('../src/services/stock');
+
+test('getStockDetail masks password', async () => {
+  const rows = await getStockDetail('X');
+  assert.deepStrictEqual(rows, [{ id:1, fifo_order:0, used_count:0, max_usage:1, status:'AVAILABLE' }]);
+  assert.ok(!('password' in rows[0]));
+});

--- a/test/transition.test.js
+++ b/test/transition.test.js
@@ -1,6 +1,8 @@
 const assert = require('node:assert');
 const { test } = require('node:test');
 
+const dbPath = require.resolve('../src/db/client');
+require.cache[dbPath] = { exports:{} };
 const { detectTransition } = require('../src/services/worker');
 
 test('detectTransition flags stock changes', () => {

--- a/test/wa-hmac.test.js
+++ b/test/wa-hmac.test.js
@@ -4,6 +4,10 @@ const express = require('express');
 
 // set env before requiring router
 process.env.WA_APP_SECRET = 'testsecret';
+const dbPath = require.resolve('../src/db/client');
+require.cache[dbPath] = { exports:{} };
+const eventsPath = require.resolve('../src/services/events');
+require.cache[eventsPath] = { exports:{ addEvent: async ()=>{} } };
 const waWebhook = require('../src/whatsapp/webhook');
 
 function startApp() {


### PR DESCRIPTION
## Summary
- Notify admins via Telegram when a customer requests help, including quick action buttons
- Alert admins on low stock per variant using thresholds and hourly idempotency keys
- Standardize WhatsApp flows with interactive buttons and remove passwords from stock detail API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae6e1b4788329b65e0b9377b87b58