### PR TITLE
Add variant sync tests, WIB stock alert and TnC decline flow

### DIFF
--- a/src/services/worker.js
+++ b/src/services/worker.js
@@ -98,8 +98,8 @@ async function lowStockAlert(){
   const summary = await getStockSummaryRaw();
   const thresholds = await prisma.thresholds.findMany();
   const map = new Map(thresholds.map(t=>[t.variant_id, t]));
-  const now = new Date();
-  const hourStr = now.toISOString().slice(0,13).replace(/[-:T]/g,'');
+  const nowWIB = new Date(new Date().toLocaleString('en-US',{timeZone:'Asia/Jakarta'}));
+  const hourStr = nowWIB.toISOString().slice(0,13).replace(/[-:T]/g,'');
   for(const s of summary){
     const th = map.get(s.variant_id);
     if(!th) continue;

--- a/test/stock-summary.test.js
+++ b/test/stock-summary.test.js
@@ -1,0 +1,30 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+
+const dbPath = require.resolve('../src/db/client');
+
+const store = {
+  variants: [{ variant_id:'V1', code:'V1' }],
+  accounts: [
+    { variant_id:'V1', status:'AVAILABLE', max_usage:1, used_count:0 },
+    { variant_id:'V1', status:'AVAILABLE', max_usage:4, used_count:1 },
+    { variant_id:'V1', status:'AVAILABLE', max_usage:2, used_count:2 },
+  ],
+};
+
+require.cache[dbPath] = { exports:{ $queryRaw: async () => {
+  const accs = store.accounts.filter(a=>a.status==='AVAILABLE');
+  const units = accs.filter(a=>a.used_count < a.max_usage).length;
+  const capacity = accs.reduce((s,a)=>s + Math.max(0,a.max_usage - a.used_count),0);
+  return [{ code:'V1', units, capacity }];
+} } };
+
+const { getStockSummary } = require('../src/services/stock');
+
+test('getStockSummary aggregates units and capacity', async () => {
+  const rows = await getStockSummary();
+  const v1 = rows.find(r=>r.code==='V1');
+  assert.ok(v1);
+  assert.strictEqual(v1.units,2);
+  assert.strictEqual(v1.capacity,4);
+});

--- a/test/tnc-flow.test.js
+++ b/test/tnc-flow.test.js
@@ -15,16 +15,19 @@ require.cache[waPath] = { exports:{
   sendImageById: async (...args)=>{ messages.push({ type:'image', args }); },
   sendImageByUrl: async (...args)=>{ messages.push({ type:'image', args }); },
 }};
+
+const order = { id:1, invoice:'INV-1', product_code:'CGPT-SHARE', qty:1, amount_cents:10000, status:'PENDING_PAYMENT', created_at:new Date(), tnc_ack_at:null };
 require.cache[ordersSvcPath] = { exports:{
-  createOrder: async () => ({ id:1, invoice:'INV-1', product_code:'CGPT-SHARE', qty:1, amount_cents:10000, status:'PENDING_PAYMENT', created_at:new Date(), tnc_ack_at:null }),
+  createOrder: async () => order,
   setPayAck: async () => {},
   requestHelp: async () => {},
 } };
 require.cache[tgPath] = { exports:{ sendMessage: async ()=>{}, buildOrderKeyboard: ()=>({}) } };
-require.cache[eventPath] = { exports:{ addEvent: async ()=>{} } };
+const events = [];
+require.cache[eventPath] = { exports:{ addEvent: async (...args)=>{ events.push(args); } } };
 require.cache[dbPath] = { exports:{
   products:{ findUnique: async ({ where }) => ({ code: where.code, is_active:true, price_cents:10000, duration_months:1, sk_text:'S&K test' }) },
-  orders:{ findFirst: async () => null, update: async ({ where, data }) => ({ id: where.id, tnc_ack_at: data.tnc_ack_at, created_at:new Date(), invoice:'INV-1', qty:1, amount_cents:10000, product_code:'CGPT-SHARE' }) },
+  orders:{ findFirst: async () => null, update: async ({ data }) => { Object.assign(order, data); return order; } },
 }};
 
 const waWebhook = require('../src/whatsapp/webhook');
@@ -45,5 +48,20 @@ test('payment instructions only after T&C ack', async () => {
   assert.strictEqual(messages[0].args[1],'S&K test');
   await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b1', title:'Setuju' } } }] } }] }] });
   assert.ok(messages.find(m=>m.type==='buttons' && m.args[1].includes('Invoice')));
+  await new Promise(r=>server.close(r));
+});
+
+test('declining T&C cancels order', async () => {
+  messages.length = 0; events.length = 0; order.status = 'PENDING_PAYMENT'; order.tnc_ack_at = null;
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  function send(body){ return fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'order CGPT-SHARE' } }] } }] }] });
+  assert.strictEqual(messages.length,1);
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b2', title:'Tolak' } } }] } }] }] });
+  assert.strictEqual(order.status, 'CANCELLED');
+  assert.ok(events.find(e=>e[1]==='TNC_DECLINED'));
+  assert.ok(messages.find(m=>m.args[1].includes('dibatalkan')));
+  assert.ok(!messages.some(m=>m.args[1].includes('Invoice')));
   await new Promise(r=>server.close(r));
 });

--- a/test/variants-sync.test.js
+++ b/test/variants-sync.test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+const crypto = require('crypto');
+
+process.env.SHEET_SYNC_SECRET = 'secret';
+const dbPath = require.resolve('../src/db/client');
+const eventPath = require.resolve('../src/services/events');
+
+const store = { variants: [] };
+require.cache[dbPath] = { exports:{ product_variants:{
+  upsert: async ({ where, create, update }) => {
+    const idx = store.variants.findIndex(v=>v.code===where.code);
+    if(idx>=0){
+      Object.assign(store.variants[idx], update);
+      return store.variants[idx];
+    }
+    const v = Object.assign({ variant_id:`v${store.variants.length+1}` }, create);
+    store.variants.push(v);
+    return v;
+  },
+  findUnique: async ({ where }) => store.variants.find(v=>v.code===where.code) || null,
+} } };
+require.cache[eventPath] = { exports:{ addEvent: async ()=>{} } };
+
+const route = require('../src/routes/variants-sync');
+
+function startApp(){
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody = buf; } }));
+  app.use('/api', route);
+  return app;
+}
+
+test('variants-sync HMAC & upsert', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  const payload = {product:'Netflix',type:'1P1U',duration_days:30,code:'NET-1P1U-30',active:true};
+  const body = JSON.stringify(payload);
+  const sig = crypto.createHmac('sha256', process.env.SHEET_SYNC_SECRET).update(body).digest('hex');
+  let res = await fetch(`http://127.0.0.1:${port}/api/variants-sync`, { method:'POST', headers:{'Content-Type':'application/json','x-signature':sig}, body });
+  assert.strictEqual(res.status,200);
+  const data = await res.json();
+  assert.deepStrictEqual(data.ok,true);
+  assert.ok(data.variant_id);
+  const firstId = data.variant_id;
+  const badSig = '0'.repeat(sig.length);
+  res = await fetch(`http://127.0.0.1:${port}/api/variants-sync`, { method:'POST', headers:{'Content-Type':'application/json','x-signature':badSig}, body });
+  assert.strictEqual(res.status,403);
+  const body2 = JSON.stringify({...payload, active:false});
+  const sig2 = crypto.createHmac('sha256', process.env.SHEET_SYNC_SECRET).update(body2).digest('hex');
+  res = await fetch(`http://127.0.0.1:${port}/api/variants-sync`, { method:'POST', headers:{'Content-Type':'application/json','x-signature':sig2}, body: body2 });
+  assert.strictEqual(res.status,200);
+  const data2 = await res.json();
+  assert.strictEqual(data2.variant_id, firstId);
+  assert.strictEqual(store.variants[0].active, false);
+  await new Promise(r=>server.close(r));
+});


### PR DESCRIPTION
## Summary
- test HMAC-protected `/api/variants-sync` including upserts
- use WIB timestamp for low stock alerts to ensure hourly idempotence
- support declining T&C from WhatsApp and cover with tests
- add stock summary aggregation test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baf6b015ac8329b56eebdf5e62b10f