### PR TITLE
feat: guard sheet/variant sync HMAC

### DIFF
--- a/src/routes/sheet-sync.js
+++ b/src/routes/sheet-sync.js
@@ -53,7 +53,9 @@ async function upsertAccountFromSheet(payload){
 router.post('/sheet-sync', express.json({ type:'application/json' }), async (req, res) => {
   const sig = req.get('x-signature');
   const expected = crypto.createHmac('sha256', SHEET_SECRET).update(req.rawBody).digest('hex');
-  if(!sig || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))){
+  if (!sig || typeof sig !== 'string' || sig.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+    await addEvent(null, 'SHEET_SYNC_INVALID_SIG', 'invalid signature', { ip: req.ip, route: req.path });
     return res.sendStatus(403);
   }
   const key = `sync:${req.ip}:${req.path}`;

--- a/src/routes/variants-sync.js
+++ b/src/routes/variants-sync.js
@@ -12,7 +12,9 @@ const router = express.Router();
 router.post('/variants-sync', express.json({ type: 'application/json' }), async (req, res) => {
   const sig = req.get('x-signature');
   const expected = crypto.createHmac('sha256', SHEET_SECRET).update(req.rawBody).digest('hex');
-  if (!sig || !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+  if (!sig || typeof sig !== 'string' || sig.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+    await addEvent(null, 'VARIANT_SYNC_INVALID_SIG', 'invalid signature', { ip: req.ip, route: req.path });
     return res.sendStatus(403);
   }
   const key = `sync:${req.ip}:${req.path}`;

--- a/test/variants-sync.test.js
+++ b/test/variants-sync.test.js
@@ -70,3 +70,17 @@ test('variants-sync invalid payload returns details', async () => {
   assert.ok(data.details.find(d=>d.path.join('.')==='type'));
   await new Promise(r=>server.close(r));
 });
+
+test('variants-sync short signature returns 403', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  const payload = { product:'Netflix', type:'1P1U', duration_days:30, code:'NET-1P1U-30' };
+  const body = JSON.stringify(payload);
+  const res = await fetch(`http://127.0.0.1:${port}/api/variants-sync`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json','x-signature':'deadbeef'},
+    body
+  });
+  assert.strictEqual(res.status,403);
+  await new Promise(r=>server.close(r));
+});


### PR DESCRIPTION
## Summary
- handle mismatched HMAC header lengths before using timingSafeEqual for sheet-sync and variants-sync
- log invalid signatures instead of throwing
- test short-signature requests return 403

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb18f7ba048329af2ab9ad5ba220de