### PR TITLE
feat: unify sheet hmac handling

### DIFF
--- a/src/routes/sheet1-webhook.js
+++ b/src/routes/sheet1-webhook.js
@@ -2,37 +2,117 @@ const express = require('express');
 const crypto = require('crypto');
 const prisma = require('../db/client');
 const { SHEET1_HMAC_SECRET } = require('../config/env');
+const { upsertAccountFromSheet } = require('./sheet-sync');
+const { addEvent } = require('../services/events');
 
 const router = express.Router();
 const SECRET = SHEET1_HMAC_SECRET || 'secret';
 
 router.post('/sheet1-webhook', express.json({ type: 'application/json' }), async (req, res) => {
-  const sig = req.get('X-Hub-Signature-256') || req.get('x-signature');
+  const sigHeader = req.get('X-Hub-Signature-256') || req.get('x-signature');
   const expected = 'sha256=' + crypto.createHmac('sha256', SECRET).update(req.rawBody).digest('hex');
-  if (!sig || sig.split('=')[1] !== expected.split('=')[1]) {
+  const provided = sigHeader && (sigHeader.startsWith('sha256=') ? sigHeader : 'sha256=' + sigHeader);
+  if (!provided || provided.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) {
+    await addEvent(null, 'SHEET_SYNC_INVALID_SIG', 'invalid signature', { route: '/sheet1-webhook', ip: req.ip });
     return res.sendStatus(403);
   }
-  const { tab_type, records } = req.body;
+  const { tab_type, records } = req.body || {};
   try {
-    if (tab_type === 'MASTER' && Array.isArray(records)) {
-      for (const r of records) {
-        if (r.kind === 'Terms') {
-          await prisma.terms.upsert({
-            where: { key: r.key },
-            update: { title: r.title, body_md: r.body_md, version: r.version || 1 },
-            create: { key: r.key, title: r.title, body_md: r.body_md, version: r.version || 1 },
-          });
-        } else if (r.kind === 'QRIS') {
-          await prisma.qris_assets.upsert({
-            where: { key: r.key },
-            update: { name: r.name, image_url: r.image_url, active: r.active !== false },
-            create: { key: r.key, name: r.name, image_url: r.image_url, active: r.active !== false },
+    await prisma.$transaction(async (tx) => {
+      const [prefix, code] = (tab_type || '').split('_');
+      if (prefix === 'MASTER' && Array.isArray(records)) {
+        for (const r of records) {
+          if (r.kind === 'Terms') {
+            await tx.terms.upsert({
+              where: { key: r.key },
+              update: { title: r.title, body_md: r.body_md, version: r.version || 1 },
+              create: { key: r.key, title: r.title, body_md: r.body_md, version: r.version || 1 },
+            });
+          } else if (r.kind === 'QRIS') {
+            await tx.qris_assets.upsert({
+              where: { key: r.key },
+              update: { name: r.name, image_url: r.image_url, active: r.active !== false },
+              create: { key: r.key, name: r.name, image_url: r.image_url, active: r.active !== false },
+            });
+          }
+        }
+      } else if (prefix === 'PROD' && code && Array.isArray(records)) {
+        for (const r of records) {
+          await tx.products.upsert({
+            where: { code },
+            create: {
+              code,
+              name: r.name || code,
+              default_tnc_key: r.default_tnc_key || null,
+              default_qris_key: r.default_qris_key || null,
+              default_mode: r.default_mode || null,
+              default_requires_email: r.default_requires_email || false,
+              default_otp_policy: r.default_otp_policy || 'NONE',
+              sorting_index: r.sorting_index ?? 10,
+              category: r.category || null,
+              approval_required: r.approval_required ?? false,
+              is_active: r.is_active !== false,
+            },
+            update: {
+              name: r.name,
+              default_tnc_key: r.default_tnc_key,
+              default_qris_key: r.default_qris_key,
+              default_mode: r.default_mode,
+              default_requires_email: r.default_requires_email,
+              default_otp_policy: r.default_otp_policy,
+              sorting_index: r.sorting_index,
+              category: r.category,
+              approval_required: r.approval_required,
+              is_active: r.is_active,
+            },
           });
         }
+      } else if (prefix === 'VAR' && code && Array.isArray(records)) {
+        for (const r of records) {
+          const vcode = r.variant_code;
+          if (!vcode) continue;
+          await tx.product_variants.upsert({
+            where: { code: vcode },
+            create: {
+              product_id: code,
+              code: vcode,
+              title: r.title || null,
+              duration_days: r.duration_days || 0,
+              price_cents: r.price || 0,
+              stock_cached: r.stock ?? null,
+              delivery_mode: r.delivery_mode || 'USERPASS',
+              requires_email: r.requires_email ?? false,
+              otp_policy: r.otp_policy || 'NONE',
+              tnc_key: r.tnc_key || null,
+              qris_key: r.qris_key || null,
+              active: r.active !== false,
+            },
+            update: {
+              title: r.title,
+              duration_days: r.duration_days,
+              price_cents: r.price,
+              stock_cached: r.stock,
+              delivery_mode: r.delivery_mode,
+              requires_email: r.requires_email,
+              otp_policy: r.otp_policy,
+              tnc_key: r.tnc_key,
+              qris_key: r.qris_key,
+              active: r.active,
+            },
+          });
+        }
+      } else if (prefix === 'STK' && code && Array.isArray(records)) {
+        for (const r of records) {
+          const payload = Object.assign({}, r, { code: r.variant_code || code });
+          await upsertAccountFromSheet(payload);
+        }
       }
-    }
+    });
+    await addEvent(null, 'SHEET_SYNC_OK', 'sheet1 processed', { tab_type, count: records?.length || 0 });
     res.json({ ok: true });
   } catch (e) {
+    await addEvent(null, 'SHEET_SYNC_FAIL', e.message, { tab_type });
     res.status(400).json({ ok: false, error: e.message });
   }
 });

--- a/src/routes/variants-sync.js
+++ b/src/routes/variants-sync.js
@@ -10,10 +10,12 @@ const SHEET_SECRET = SHEET_SYNC_SECRET || 'secret';
 const router = express.Router();
 
 router.post('/variants-sync', express.json({ type: 'application/json' }), async (req, res) => {
-  const sig = req.get('x-signature');
-  const expected = crypto.createHmac('sha256', SHEET_SECRET).update(req.rawBody).digest('hex');
-  if (!sig || typeof sig !== 'string' || sig.length !== expected.length ||
-      !crypto.timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) {
+  const sigHeader = req.get('X-Hub-Signature-256') || req.get('x-signature');
+  const expected = 'sha256=' +
+    crypto.createHmac('sha256', SHEET_SECRET).update(req.rawBody).digest('hex');
+  const provided = sigHeader && (sigHeader.startsWith('sha256=') ? sigHeader : 'sha256=' + sigHeader);
+  if (!provided || provided.length !== expected.length ||
+      !crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) {
     await addEvent(null, 'VARIANT_SYNC_INVALID_SIG', 'invalid signature', { ip: req.ip, route: req.path });
     return res.sendStatus(403);
   }

--- a/test/sheet-sync-validation.test.js
+++ b/test/sheet-sync-validation.test.js
@@ -20,9 +20,9 @@ function startApp(){
 test('sheet-sync invalid payload returns details', async () => {
   const app = startApp();
   const server = app.listen(0); const port = server.address().port;
-  const body = JSON.stringify({});
+  const body = JSON.stringify({ code: 123 });
   const sig = crypto.createHmac('sha256', process.env.SHEET_SYNC_SECRET).update(body).digest('hex');
-  const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','x-signature':sig}, body });
+  const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':'sha256='+sig}, body });
   assert.strictEqual(res.status,400);
   const data = await res.json();
   assert.strictEqual(data.error,'VALIDATION_ERROR');
@@ -37,7 +37,7 @@ test('sheet-sync requires natural_key when username empty', async () => {
   const payload = { code:'C', username:'', password:'p' };
   const body = JSON.stringify(payload);
   const sig = crypto.createHmac('sha256', process.env.SHEET_SYNC_SECRET).update(body).digest('hex');
-  const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','x-signature':sig}, body });
+  const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':'sha256='+sig}, body });
   assert.strictEqual(res.status,400);
   const data = await res.json();
   assert.strictEqual(data.error,'VALIDATION_ERROR');
@@ -51,7 +51,7 @@ test('sheet-sync short signature returns 403', async () => {
   const body = JSON.stringify({ code:'C', username:'u', password:'p' });
   const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, {
     method:'POST',
-    headers:{'Content-Type':'application/json','x-signature':'deadbeef'},
+    headers:{'Content-Type':'application/json','X-Hub-Signature-256':'sha256=deadbeef'},
     body
   });
   assert.strictEqual(res.status,403);

--- a/test/variants-per-product-tabs.test.js
+++ b/test/variants-per-product-tabs.test.js
@@ -1,6 +1,83 @@
-const test = require('node:test');
 const assert = require('node:assert');
+const { test } = require('node:test');
+const express = require('express');
+const crypto = require('crypto');
 
-test('placeholder', () => {
-  assert.ok(true);
+process.env.SHEET1_HMAC_SECRET = 'secret';
+
+const dbPath = require.resolve('../src/db/client');
+const sheetSyncPath = require.resolve('../src/routes/sheet-sync');
+const eventPath = require.resolve('../src/services/events');
+
+const store = { products: [], variants: [], accounts: [] };
+
+require.cache[dbPath] = { exports: {
+  products: {
+    upsert: async ({ where, create, update }) => {
+      let p = store.products.find(p => p.code === where.code);
+      if (p) { Object.assign(p, update); return p; }
+      p = Object.assign({ code: where.code }, create);
+      store.products.push(p); return p;
+    }
+  },
+  product_variants: {
+    upsert: async ({ where, create, update }) => {
+      let v = store.variants.find(v => v.code === where.code);
+      if (v) { Object.assign(v, update); return v; }
+      v = Object.assign({ code: where.code, variant_id: 'v'+(store.variants.length+1) }, create);
+      store.variants.push(v); return v;
+    }
+  },
+  accounts: {
+    upsert: async ({ where, create, update }) => {
+      let a = store.accounts.find(a=>a.natural_key===where.natural_key);
+      if (a) { Object.assign(a, update); return a; }
+      a = Object.assign({ id: store.accounts.length+1 }, create);
+      store.accounts.push(a); return a;
+    }
+  },
+  terms:{ upsert: async ()=>{} },
+  qris_assets:{ upsert: async ()=>{} },
+  $transaction: async fn => fn(require.cache[dbPath].exports)
+}};
+
+require.cache[sheetSyncPath] = { exports:{ upsertAccountFromSheet: async (payload) => { store.accounts.push(payload); } } };
+require.cache[eventPath] = { exports:{ addEvent: async ()=>{} } };
+
+const route = require('../src/routes/sheet1-webhook');
+
+function startApp(){
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody = buf; } }));
+  app.use('/api', route);
+  return app;
+}
+
+test('sheet1 tab per product handling', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+
+  let body = JSON.stringify({ tab_type:'PROD_NET', records:[{ name:'Netflix', default_mode:'USERPASS', is_active:true }] });
+  let sig = 'sha256='+crypto.createHmac('sha256', process.env.SHEET1_HMAC_SECRET).update(body).digest('hex');
+  let res = await fetch(`http://127.0.0.1:${port}/api/sheet1-webhook`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig}, body });
+  assert.strictEqual(res.status,200);
+  assert.strictEqual(store.products.length,1);
+  assert.strictEqual(store.products[0].default_mode,'USERPASS');
+
+  body = JSON.stringify({ tab_type:'VAR_NET', records:[{ variant_code:'NET-1', title:'Basic', duration_days:30, price:1000, stock:5, delivery_mode:'USERPASS', active:true }] });
+  sig = 'sha256='+crypto.createHmac('sha256', process.env.SHEET1_HMAC_SECRET).update(body).digest('hex');
+  res = await fetch(`http://127.0.0.1:${port}/api/sheet1-webhook`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig}, body });
+  assert.strictEqual(res.status,200);
+  assert.strictEqual(store.variants.length,1);
+  assert.strictEqual(store.variants[0].price_cents,1000);
+
+  body = JSON.stringify({ tab_type:'STK_NET', records:[{ variant_code:'NET-1', username:'u', password:'p' }, { variant_code:'NET-1', username:'d', password:'p', __op:'DELETE' }] });
+  sig = 'sha256='+crypto.createHmac('sha256', process.env.SHEET1_HMAC_SECRET).update(body).digest('hex');
+  res = await fetch(`http://127.0.0.1:${port}/api/sheet1-webhook`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig}, body });
+  assert.strictEqual(res.status,200);
+  assert.strictEqual(store.accounts.length,2);
+  assert.strictEqual(store.accounts[0].code,'NET-1');
+  assert.strictEqual(store.accounts[1].__op,'DELETE');
+
+  await new Promise(r=>server.close(r));
 });


### PR DESCRIPTION
## Summary
- support standard `X-Hub-Signature-256` HMAC verification with fallback for legacy `x-signature`
- expand sheet1 webhook to process product, variant, and stock tabs in one transaction
- cover new per-product sheet syncing in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcacd489888329aeb89d613a1304be