### PR TITLE
feat: add WhatsApp variant selection

### DIFF
--- a/src/services/wa.js
+++ b/src/services/wa.js
@@ -35,7 +35,27 @@ function sendInteractiveButtons(to, bodyText, buttons){
     interactive: { type: 'button', body: { text: bodyText }, action: { buttons: combined.slice(0, 3) } },
   });
 }
-function sendListMenu(to, header, bodyText, sections){ return waCall('messages', { messaging_product:'whatsapp', to, type:'interactive', interactive:{ type:'list', header:{ type:'text', text: header }, body:{ text: bodyText }, action:{ button:'Pilih', sections: sections.map(s=>({ title:s.title, rows: s.rows.map(r=>({ id:r.id, title:r.title, description:r.desc||'' })) })) } } }); }
+function sendListMenu(jid, title, buttonText, sections){
+  return waCall('messages', {
+    messaging_product: 'whatsapp',
+    to: jid,
+    type: 'interactive',
+    interactive: {
+      type: 'list',
+      body: { text: title },
+      action: {
+        button: buttonText,
+        sections: sections.map(s => ({
+          title: s.title,
+          rows: s.rows.map(r => ({ id: r.id, title: r.title, description: r.desc || '' }))
+        }))
+      }
+    }
+  });
+}
+function formatRp(cents){
+  return new Intl.NumberFormat('id-ID',{ style:'currency', currency:'IDR', minimumFractionDigits:0, maximumFractionDigits:0 }).format(cents/100);
+}
 function sendImageById(to, mediaId, caption){ return waCall('messages', { messaging_product:'whatsapp', to, type:'image', image:{ id: mediaId, caption } }); }
 function sendImageByUrl(to, url, caption){ return waCall('messages', { messaging_product:'whatsapp', to, type:'image', image:{ link: url, caption } }); }
-module.exports = { sendText, sendInteractiveButtons, sendListMenu, sendImageById, sendImageByUrl, waCall };
+module.exports = { sendText, sendInteractiveButtons, sendListMenu, sendImageById, sendImageByUrl, waCall, formatRp };


### PR DESCRIPTION
## Summary
- show product variants with price and stock through WhatsApp list menu
- handle variant selection storing variant in session before ordering
- add list menu helper and Rupiah formatter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd902df6cc832991661dfab45de104