### PR TITLE
feat: add DB-backed terms acknowledgement flow

### DIFF
--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -110,6 +110,12 @@ async function setPayAck(invoice){
   return { ok:true, order:upd };
 }
 
+async function ackTerms(orderId){
+  const upd = await prisma.orders.update({ where:{ id: orderId }, data:{ tnc_ack_at: new Date() } });
+  await addEvent(orderId, 'TNC_CONFIRMED', 'terms accepted');
+  return upd;
+}
+
 async function confirmPaid(invoice){
   const order = await prisma.orders.findUnique({ where:{ invoice }, include:{ product:true, account:true } });
   if(!order) return { ok:false, error:'ORDER_NOT_FOUND' };
@@ -222,4 +228,4 @@ async function cancel(orderId){
   return upd;
 }
 
-module.exports = { createOrder, setPayAck, confirmPaid, rejectOrder, markInvited, approvePreapproval, rejectPreapproval, reserveAccount, requestHelp, resume, skipStage, cancel };
+module.exports = { createOrder, setPayAck, confirmPaid, rejectOrder, markInvited, approvePreapproval, rejectPreapproval, reserveAccount, ackTerms, requestHelp, resume, skipStage, cancel };


### PR DESCRIPTION
## Summary
- fetch variant/product T&C from `terms` table and prompt user to accept
- add `ackTerms` service to record `tnc_ack_at` and emit `TNC_CONFIRMED`
- skip QRIS, show payment summary after terms acceptance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd92afaea48329ba5335da8d4f6c6e