### PR TITLE
Wire Sheet-2 publishers for orders and stock

### DIFF
--- a/src/services/stock.js
+++ b/src/services/stock.js
@@ -1,4 +1,5 @@
 const prisma = require('../db/client');
+const { publishStock } = require('./output');
 
 async function getStockSummary(){
   return prisma.$queryRaw`SELECT v.code,
@@ -26,4 +27,9 @@ async function getStockDetail(code){
     ORDER BY a.fifo_order ASC, a.id ASC`;
 }
 
-module.exports = { getStockSummary, getStockSummaryRaw, getStockDetail };
+async function publishStockSummary(){
+  const rows = await getStockSummary();
+  return publishStock(rows);
+}
+
+module.exports = { getStockSummary, getStockSummaryRaw, getStockDetail, publishStockSummary };


### PR DESCRIPTION
## Summary
- publish order status changes to Sheet-2
- broadcast stock summary whenever accounts are reserved or disabled

## Testing
- `npm test` *(fails: process hung after running tests, see tail output)*

------
https://chatgpt.com/codex/tasks/task_e_68bdadf00c7483298203a033f45d3f06