### PR TITLE
Add minimal tests for terms, QRIS, OTP, and sheet-sync publishers

### DIFF
--- a/test/otp-flows.test.js
+++ b/test/otp-flows.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const otpPath = require.resolve('../src/services/otp');
+const dbPath = require.resolve('../src/db/client');
+
+const tokens = new Map();
+
+require.cache[dbPath] = { exports: {
+  otptokens: {
+    create: async ({ data }) => { tokens.set(data.id, Object.assign({ used:false, used_count:0 }, data)); return data; },
+    findUnique: async ({ where:{ id } }) => tokens.get(id) || null,
+    update: async ({ where:{ id }, data }) => { Object.assign(tokens.get(id), data); return tokens.get(id); },
+    findFirst: async ({ where:{ order_id, type } }) => {
+      for (const t of tokens.values()) if (t.order_id===order_id && t.type===type) return t;
+      return null;
+    }
+  }
+}};
+
+delete require.cache[otpPath];
+const { createManualToken, fulfillManualOtp, generateSingleUseTOTP } = require(otpPath);
+
+test('manual OTP token fulfillment is idempotent', async () => {
+  const id = await createManualToken(1, 60);
+  const order = await fulfillManualOtp(id, '123456');
+  assert.strictEqual(order, 1);
+  assert.strictEqual(tokens.get(id).used, true);
+  const second = await fulfillManualOtp(id, '123456');
+  assert.strictEqual(second, null);
+});
+
+test('single use TOTP can only be generated once', async () => {
+  const code1 = await generateSingleUseTOTP(2, 'JBSWY3DPEHPK3PXP');
+  assert.ok(code1);
+  const code2 = await generateSingleUseTOTP(2, 'JBSWY3DPEHPK3PXP');
+  assert.strictEqual(code2, null);
+});

--- a/test/qris-per-variant.test.js
+++ b/test/qris-per-variant.test.js
@@ -1,39 +1,37 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-const ordersPath = require.resolve('../src/services/orders');
-const dbPath = require.resolve('../src/db/client');
-const variantPath = require.resolve('../src/services/variants');
-const eventPath = require.resolve('../src/services/events');
+process.env.WA_ACCESS_TOKEN = 't';
+process.env.WA_PHONE_NUMBER_ID = '1';
+process.env.WA_API_BASE = 'https://wa.example';
 
-// helper to require fresh orders module with mocks
-function loadOrdersWithMocks({ variantQris }){
-  const createArgs = {};
-  require.cache[eventPath] = { exports:{ addEvent: async ()=>{} } };
-  require.cache[variantPath] = { exports:{ resolveVariantByCode: async ()=>({
-    variant_id:'v1', product_id:'P1', price_cents:500, delivery_mode:'USERPASS', qris_key: variantQris, duration_days:30
-  }) } };
-  require.cache[dbPath] = { exports:{
-    products:{ findUnique: async ()=>({ code:'P1', default_qris_key:'QD', approval_required:false, default_mode:'USERPASS' }) },
-    orders:{ create: async ({ data })=>{ createArgs.data=data; return { id:1, ...data }; } },
-    preapprovalrequests:{ create: async ()=>({ id:1 }) }
+const waPath = require.resolve('../src/services/wa');
+const dbPath = require.resolve('../src/db/client');
+
+function setup({ variantKey, productKey }){
+  const calls = [];
+  global.fetch = async (_url, opts) => {
+    calls.push(JSON.parse(opts.body));
+    return { ok: true, json: async () => ({}) };
+  };
+  require.cache[dbPath] = { exports: {
+    product_variants: { findUnique: async () => ({ qris_key: variantKey }) },
+    products: { findUnique: async () => ({ default_qris_key: productKey }) },
+    qris_assets: { findUnique: async ({ where:{ key } }) => ({ image_url: `https://img/${key}.png` }) }
   }};
-  delete require.cache[ordersPath];
-  const svc = require(ordersPath);
-  return { createOrder: svc.createOrder, createArgs };
+  delete require.cache[waPath];
+  const { sendQrisPayment } = require(waPath);
+  return { sendQrisPayment, calls };
 }
 
-test('uses variant qris over product default', async () => {
-  const { createOrder, createArgs } = loadOrdersWithMocks({ variantQris: 'QV' });
-  const order = await createOrder({ buyer_phone:'123', product_code:'P1', variant_code:'V1', qty:2 });
-  assert.strictEqual(order.qris_key, 'QV');
-  assert.strictEqual(createArgs.data.amount_cents, 1000);
-  assert.strictEqual(order.variant_id, 'v1');
+test('variant QRIS image is used when available', async () => {
+  const { sendQrisPayment, calls } = setup({ variantKey: 'QV', productKey: 'QD' });
+  await sendQrisPayment('1', { invoice:'INV', amount_cents:1000, variant_id:'v1' });
+  assert.strictEqual(calls[0].image.link, 'https://img/QV.png');
 });
 
-test('falls back to product qris when variant missing', async () => {
-  const { createOrder, createArgs } = loadOrdersWithMocks({ variantQris: null });
-  const order = await createOrder({ buyer_phone:'123', product_code:'P1', variant_code:'V1', qty:2 });
-  assert.strictEqual(order.qris_key, 'QD');
-  assert.strictEqual(createArgs.data.amount_cents, 1000);
+test('falls back to product QRIS image when variant missing', async () => {
+  const { sendQrisPayment, calls } = setup({ variantKey: null, productKey: 'QD' });
+  await sendQrisPayment('1', { invoice:'INV', amount_cents:1000, variant_id:'v1', product_code:'P1' });
+  assert.strictEqual(calls[0].image.link, 'https://img/QD.png');
 });

--- a/test/sheet2-publisher-on-sheet-sync.test.js
+++ b/test/sheet2-publisher-on-sheet-sync.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const express = require('express');
+const crypto = require('crypto');
+
+const routePath = require.resolve('../src/routes/sheet-sync');
+const dbPath = require.resolve('../src/db/client');
+const variantPath = require.resolve('../src/services/variants');
+const eventPath = require.resolve('../src/services/events');
+const outputPath = require.resolve('../src/services/output');
+const stockPath = require.resolve('../src/services/stock');
+
+const store = { accounts: [] };
+let publishStockCalled = 0;
+
+require.cache[outputPath] = { exports:{ publishStock: async () => { publishStockCalled++; } } };
+require.cache[variantPath] = { exports:{ resolveVariantByCode: async () => ({ variant_id:'v1', product:'P', code:'C', active:true }) } };
+require.cache[eventPath] = { exports:{ addEvent: async () => {} } };
+require.cache[dbPath] = { exports:{
+  $queryRaw: async () => [],
+  accounts:{
+    upsert: async ({ where, create, update }) => {
+      const idx = store.accounts.findIndex(a=>a.natural_key===where.natural_key);
+      if(idx===-1){ const acc = Object.assign({ id:store.accounts.length+1 }, create); store.accounts.push(acc); return acc; }
+      Object.assign(store.accounts[idx], update); return store.accounts[idx];
+    },
+    findUnique: async ({ where }) => store.accounts.find(a=>a.natural_key===where.natural_key) || null,
+  }
+}};
+
+delete require.cache[stockPath];
+const stockMod = require(stockPath);
+const realPublishStockSummary = stockMod.publishStockSummary;
+let publishStockSummaryCalled = 0;
+stockMod.publishStockSummary = async function(...args){ publishStockSummaryCalled++; return realPublishStockSummary(...args); };
+
+delete require.cache[routePath];
+const router = require(routePath);
+
+function startApp(){
+  const app = express();
+  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use('/', router);
+  return app;
+}
+
+test('sheet-sync triggers stock publishers', async () => {
+  const app = startApp();
+  const server = app.listen(0); const port = server.address().port;
+  function sig(body){ return 'sha256='+crypto.createHmac('sha256','secret').update(body).digest('hex'); }
+  async function send(payload){
+    const body = JSON.stringify(payload);
+    await fetch(`http://127.0.0.1:${port}/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig(body)}, body });
+  }
+  await send({ code:'C', username:'u', password:'p' });
+  await send({ code:'C', username:'u', __op:'DELETE' });
+  assert.strictEqual(publishStockSummaryCalled,2);
+  assert.strictEqual(publishStockCalled,2);
+  await new Promise(r=>server.close(r));
+});

--- a/test/tnc-from-db.test.js
+++ b/test/tnc-from-db.test.js
@@ -23,7 +23,10 @@ require.cache[ordersSvcPath] = { exports:{
   ackTerms: async ()=>{ order.tnc_ack_at = new Date(); return order; },
 }};
 require.cache[dbPath] = { exports:{
-  products:{ findUnique: async ()=>({ code:'P1', name:'Prod', price_cents:1000, is_active:true, default_tnc_key:'T1', default_mode:'USERPASS' }) },
+  product_variants:{ findUnique: async ()=>({
+    variant_id:'v1', code:'V1', title:'Var', price_cents:1000, active:true, tnc_key:'T1',
+    product:{ code:'P1', name:'Prod', price_cents:1000, is_active:true }
+  }) },
   terms:{ findUnique: async ()=>({ key:'T1', body_md:'S&K dari DB' }) },
   orders:{
     update: async ({ data })=>{ Object.assign(order,data); return order; },
@@ -44,7 +47,7 @@ test('terms loaded from DB and ack time set', async () => {
   const app = startApp();
   const server = app.listen(0); const port = server.address().port;
   function send(body){ return fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
-  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'order P1' } }] } }] }] });
+  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ list_reply:{ id:'var:v1' } } }] } }] }] });
   assert.strictEqual(messages[0].args[1], 'S\u0026K dari DB');
   await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b1', title:'Setuju' } } }] } }] }] });
   assert.ok(order.tnc_ack_at instanceof Date);


### PR DESCRIPTION
## Summary
- ensure TNC uses DB terms and records ack timestamp
- verify QRIS payment uses variant image or product fallback
- cover manual and TOTP OTP flows for idempotency
- check sheet-sync triggers stock publishers on upsert/delete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc9a7cb588329bac5c37663f57670