### PR TITLE
Add manual OTP single-use test

### DIFF
--- a/test/otp-manual-disney.test.js
+++ b/test/otp-manual-disney.test.js
@@ -1,6 +1,37 @@
 const test = require('node:test');
 const assert = require('node:assert');
 
-test('placeholder', () => {
-  assert.ok(true);
+const otpPath = require.resolve('../src/services/otp');
+const dbPath = require.resolve('../src/db/client');
+
+test('manual OTP token only usable once', async () => {
+  const tokens = new Map();
+  require.cache[dbPath] = { exports: {
+    otptokens: {
+      create: async ({ data }) => { tokens.set(data.id, { ...data, used: false, used_count: 0 }); return data; },
+      findUnique: async ({ where: { id } }) => tokens.get(id) || null,
+      update: async ({ where: { id }, data }) => {
+        const t = tokens.get(id);
+        if ('code_hash' in data) t.code_hash = data.code_hash;
+        if ('used' in data) t.used = data.used;
+        if (data.used_count && typeof data.used_count.increment === 'number') {
+          t.used_count += data.used_count.increment;
+        }
+        return t;
+      }
+    }
+  }};
+
+  delete require.cache[otpPath];
+  const { createManualToken, fulfillManualOtp } = require(otpPath);
+
+  const tokenId = await createManualToken(42, 1);
+  const order = await fulfillManualOtp(tokenId, '123456');
+
+  assert.strictEqual(order, 42);
+  assert.strictEqual(tokens.get(tokenId).used, true);
+
+  const second = await fulfillManualOtp(tokenId, '123456');
+  assert.strictEqual(second, null);
 });
+


### PR DESCRIPTION
## Summary
- add test covering manual OTP token lifecycle

## Testing
- `node --test test/otp-manual-disney.test.js`
- `node --test test/otp-totp-chatgpt.test.js`
- `npm test` *(fails: confirmPaid called twice does not re-deliver; only one confirmation succeeds reserving stock; fallback by product_code and auto-disable when max usage reached; deleted flag disables account)*

------
https://chatgpt.com/codex/tasks/task_e_68bde3ee58dc8329a02b2d1334b62382