### PR TITLE
test: ensure stock publisher called on sheet sync

### DIFF
--- a/test/sheet2-publisher-on-sheet-sync.test.js
+++ b/test/sheet2-publisher-on-sheet-sync.test.js
@@ -7,13 +7,10 @@ const routePath = require.resolve('../src/routes/sheet-sync');
 const dbPath = require.resolve('../src/db/client');
 const variantPath = require.resolve('../src/services/variants');
 const eventPath = require.resolve('../src/services/events');
-const outputPath = require.resolve('../src/services/output');
 const stockPath = require.resolve('../src/services/stock');
 
 const store = { accounts: [] };
-let publishStockCalled = 0;
 
-require.cache[outputPath] = { exports:{ publishStock: async () => { publishStockCalled++; } } };
 require.cache[variantPath] = { exports:{ resolveVariantByCode: async () => ({ variant_id:'v1', product:'P', code:'C', active:true }) } };
 require.cache[eventPath] = { exports:{ addEvent: async () => {} } };
 require.cache[dbPath] = { exports:{
@@ -22,17 +19,14 @@ require.cache[dbPath] = { exports:{
     upsert: async ({ where, create, update }) => {
       const idx = store.accounts.findIndex(a=>a.natural_key===where.natural_key);
       if(idx===-1){ const acc = Object.assign({ id:store.accounts.length+1 }, create); store.accounts.push(acc); return acc; }
-      Object.assign(store.accounts[idx], update); return store.accounts[idx];
+      const acc = store.accounts[idx]; Object.assign(acc, update); return acc;
     },
     findUnique: async ({ where }) => store.accounts.find(a=>a.natural_key===where.natural_key) || null,
   }
 }};
 
-delete require.cache[stockPath];
-const stockMod = require(stockPath);
-const realPublishStockSummary = stockMod.publishStockSummary;
 let publishStockSummaryCalled = 0;
-stockMod.publishStockSummary = async function(...args){ publishStockSummaryCalled++; return realPublishStockSummary(...args); };
+require.cache[stockPath] = { exports:{ publishStockSummary: async () => { publishStockSummaryCalled++; throw new Error('boom'); } } };
 
 delete require.cache[routePath];
 const router = require(routePath);
@@ -40,21 +34,21 @@ const router = require(routePath);
 function startApp(){
   const app = express();
   app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
-  app.use('/', router);
+  app.use('/api', router);
   return app;
 }
 
-test('sheet-sync triggers stock publishers', async () => {
+test('publishStockSummary called on upsert and delete without affecting response', async () => {
   const app = startApp();
   const server = app.listen(0); const port = server.address().port;
   function sig(body){ return 'sha256='+crypto.createHmac('sha256','secret').update(body).digest('hex'); }
   async function send(payload){
     const body = JSON.stringify(payload);
-    await fetch(`http://127.0.0.1:${port}/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig(body)}, body });
+    const res = await fetch(`http://127.0.0.1:${port}/api/sheet-sync`, { method:'POST', headers:{'Content-Type':'application/json','X-Hub-Signature-256':sig(body)}, body });
+    assert.strictEqual(res.status,200);
   }
-  await send({ code:'C', username:'u', password:'p' });
-  await send({ code:'C', username:'u', __op:'DELETE' });
+  await send({ code:'C', username:'STK_u', password:'p' });
+  await send({ code:'C', username:'STK_u', __op:'DELETE' });
   assert.strictEqual(publishStockSummaryCalled,2);
-  assert.strictEqual(publishStockCalled,2);
   await new Promise(r=>server.close(r));
 });


### PR DESCRIPTION
## Summary
- test that POST /api/sheet-sync triggers publishStockSummary on upsert and delete
- verify publisher errors are caught and don't affect response

## Testing
- `npm test -- test/sheet2-publisher-on-sheet-sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be901570448329ba926e94954f1468