### PR TITLE
test: ensure low stock alert idem per WIB hour

### DIFF
--- a/test/low-stock-alert.test.js
+++ b/test/low-stock-alert.test.js
@@ -8,16 +8,37 @@ const dbPath = require.resolve('../src/db/client');
 
 require.cache[stockPath] = { exports:{ getStockSummaryRaw: async () => ([{ code:'A', variant_id:'v1', units:1, capacity:2 }]) } };
 const events = [];
-require.cache[eventPath] = { exports:{ addEvent: async (...args) => { events.push(args); return {}; } } };
+require.cache[eventPath] = { exports:{ addEvent: async (...args) => { events.push({ kind: args[1], idem: args[6] }); return {}; } } };
 const notes = [];
 require.cache[tgPath] = { exports:{ notifyAdmin: async (txt) => { notes.push(txt); } } };
 require.cache[dbPath] = { exports:{ thresholds:{ findMany: async () => ([{ variant_id:'v1', low_stock_units:2, low_stock_capacity:3 }]) } } };
+
+const RealDate = Date;
+function setTime(iso){
+  const ms = new RealDate(iso).getTime();
+  global.Date = class extends RealDate {
+    constructor(...args){
+      if(args.length===0) return new RealDate(ms);
+      return new RealDate(...args);
+    }
+    static now(){ return ms; }
+  };
+}
+function reset(){ global.Date = RealDate; }
 
 delete require.cache[require.resolve('../src/services/worker')];
 const { lowStockAlert } = require('../src/services/worker');
 
 test('lowStockAlert triggers when below threshold', async () => {
-  await lowStockAlert();
-  assert.strictEqual(events.length,1);
-  assert.strictEqual(notes.length,1);
+  try {
+    setTime('2025-09-05T08:59:30+07:00');
+    await lowStockAlert();
+    assert.strictEqual(events.length,1);
+    assert.strictEqual(notes.length,1);
+    assert.strictEqual(events[0].kind,'LOW_STOCK_ALERT');
+    assert.strictEqual(events[0].idem,'lowstock:A:2025090508');
+  } finally {
+    reset();
+  }
 });
+

--- a/test/low-stock-wib-idem.test.js
+++ b/test/low-stock-wib-idem.test.js
@@ -36,17 +36,19 @@ function reset(){ global.Date = RealDate; }
 
 test('lowStockAlert idempotent per WIB hour', async () => {
   try {
-    setTime('2025-09-05T08:59:30+07:00');
+    setTime('2025-09-05T08:00:10+07:00');
     await lowStockAlert();
     assert.strictEqual(events.length,1);
+    assert.strictEqual(events[0].kind,'LOW_STOCK_ALERT');
     assert.strictEqual(events[0].idem,'lowstock:NET-1P1U-30:2025090508');
+    setTime('2025-09-05T08:59:20+07:00');
+    await lowStockAlert();
+    assert.strictEqual(events.length,1);
     setTime('2025-09-05T09:00:05+07:00');
     await lowStockAlert();
     assert.strictEqual(events.length,2);
+    assert.strictEqual(events[1].kind,'LOW_STOCK_ALERT');
     assert.strictEqual(events[1].idem,'lowstock:NET-1P1U-30:2025090509');
-    setTime('2025-09-05T09:00:20+07:00');
-    await lowStockAlert();
-    assert.strictEqual(events.length,2);
   } finally {
     reset();
   }


### PR DESCRIPTION
## Summary
- test low stock alert event id format
- verify low stock alert events are idempotent per WIB hour

## Testing
- `npm test test/low-stock-alert.test.js test/low-stock-wib-idem.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68be91ddb068832983f2d87caf00c796