### PR TITLE
test: ensure OTP tokens are single use

### DIFF
--- a/test/otp-manual-disney.test.js
+++ b/test/otp-manual-disney.test.js
@@ -6,30 +6,36 @@ const dbPath = require.resolve('../src/db/client');
 
 test('manual OTP token only usable once', async () => {
   const tokens = new Map();
-  require.cache[dbPath] = { exports: {
-    otptokens: {
-      create: async ({ data }) => { tokens.set(data.id, { ...data, used: false, used_count: 0 }); return data; },
-      findUnique: async ({ where: { id } }) => tokens.get(id) || null,
-      update: async ({ where: { id }, data }) => {
-        const t = tokens.get(id);
-        if ('code_hash' in data) t.code_hash = data.code_hash;
-        if ('used' in data) t.used = data.used;
-        if (data.used_count && typeof data.used_count.increment === 'number') {
-          t.used_count += data.used_count.increment;
+  require.cache[dbPath] = {
+    exports: {
+      otptokens: {
+        create: async ({ data }) => {
+          tokens.set(data.id, { ...data, used: false, used_count: 0 });
+          return data;
+        },
+        findUnique: async ({ where: { id } }) => tokens.get(id) ?? null,
+        update: async ({ where: { id }, data }) => {
+          const t = tokens.get(id);
+          if ('code_hash' in data) t.code_hash = data.code_hash;
+          if ('used' in data) t.used = data.used;
+          if (data.used_count && typeof data.used_count.increment === 'number') {
+            t.used_count += data.used_count.increment;
+          }
+          return t;
         }
-        return t;
       }
     }
-  }};
+  };
 
   delete require.cache[otpPath];
   const { createManualToken, fulfillManualOtp } = require(otpPath);
 
-  const tokenId = await createManualToken(42, 1);
+  const tokenId = await createManualToken(99, 1);
   const order = await fulfillManualOtp(tokenId, '123456');
 
-  assert.strictEqual(order, 42);
+  assert.strictEqual(order, 99);
   assert.strictEqual(tokens.get(tokenId).used, true);
+  assert.strictEqual(tokens.get(tokenId).used_count, 1);
 
   const second = await fulfillManualOtp(tokenId, '123456');
   assert.strictEqual(second, null);


### PR DESCRIPTION
## Summary
- test manual OTP token is marked used and rejected on second use
- test single-use TOTP generator returns code only once per order

## Testing
- `node --test test/otp-manual-disney.test.js test/otp-totp-chatgpt.test.js`
- `npm test` *(fails: Expected values to be strictly equal: 0 !== 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bea43fca588329b6b95b20a8207898