### PR TITLE
test: verify stock publisher triggered on sheet sync

### DIFF
--- a/test/sheet2-publisher-on-sheet-sync.test.js
+++ b/test/sheet2-publisher-on-sheet-sync.test.js
@@ -25,8 +25,8 @@ require.cache[dbPath] = { exports:{
   }
 }};
 
-let publishStockSummaryCalled = 0;
-require.cache[stockPath] = { exports:{ publishStockSummary: async () => { publishStockSummaryCalled++; throw new Error('boom'); } } };
+const publishStockSummary = test.mock.fn(async () => { throw new Error('boom'); });
+require.cache[stockPath] = { exports:{ publishStockSummary } };
 
 delete require.cache[routePath];
 const router = require(routePath);
@@ -48,7 +48,8 @@ test('publishStockSummary called on upsert and delete without affecting response
     assert.strictEqual(res.status,200);
   }
   await send({ code:'C', username:'STK_u', password:'p' });
+  assert.strictEqual(publishStockSummary.mock.calls.length,1);
   await send({ code:'C', username:'STK_u', __op:'DELETE' });
-  assert.strictEqual(publishStockSummaryCalled,2);
+  assert.strictEqual(publishStockSummary.mock.calls.length,2);
   await new Promise(r=>server.close(r));
 });


### PR DESCRIPTION
## Summary
- spy on stock summary publisher during sheet sync
- assert publisher called on upsert and soft-delete operations

## Testing
- `npm test test/sheet2-publisher-on-sheet-sync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bea55774cc83299d191a68f7341589