### PR TITLE
test: add idempotent claim ewallet flow tests

### DIFF
--- a/test/wa-claim-ewallet.test.js
+++ b/test/wa-claim-ewallet.test.js
@@ -4,33 +4,29 @@ const express = require('express');
 
 process.env.WA_APP_SECRET = '';
 const waPath = require.resolve('../src/services/wa');
-const claimSvcPath = require.resolve('../src/services/claims');
 const dbPath = require.resolve('../src/db/client');
 const tgPath = require.resolve('../src/services/telegram');
 
 const messages = [];
 const ewalletCalls = [];
+const store = { claim: { id:1, refund_cents:5000, status:'APPROVED', ewallet:null, order:{ buyer_phone:'1' } } };
 require.cache[waPath] = { exports: {
   sendText: async (...args) => { messages.push({ type:'text', args }); },
   sendInteractiveButtons: async (...args) => { messages.push({ type:'buttons', args }); },
   sendListMenu: async () => {},
 } };
-require.cache[claimSvcPath] = { exports: {
-  createClaim: async () => {},
-  approveClaim: async () => {},
-  rejectClaim: async () => {},
-  setEwallet: async (id, ew) => { ewalletCalls.push({ id, ew }); },
-  markRefunded: async () => {},
-  requestEwallet: async () => { await require.cache[waPath].exports.sendText('1','msg'); return { phone: '1' }; },
-} };
 require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
 require.cache[dbPath] = { exports: {
   warrantyclaims: {
-    findUnique: async () => ({ id:1, refund_cents:5000, order:{ buyer_phone:'1' } }),
-    update: async () => ({}),
+    findUnique: async () => ({ ...store.claim }),
+    update: async ({ data }) => { Object.assign(store.claim, data); return { ...store.claim }; },
   },
   orders: { findFirst: async () => null },
 } };
+
+const claims = require('../src/services/claims');
+const origSet = claims.setEwallet;
+claims.setEwallet = async (id, ew) => { ewalletCalls.push({ id, ew }); return await origSet(id, ew); };
 
 const waWebhook = require('../src/whatsapp/webhook');
 const claimsRoute = require('../src/routes/claims');
@@ -50,6 +46,7 @@ test('claim approval asks for ewallet and stores number', async () => {
   function send(path, body){ return fetch(`http://127.0.0.1:${port}${path}`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
   await send('/claims/1/request-ewallet', {});
   assert.strictEqual(messages.length,1);
+  assert.ok(messages[0].args[1].includes('Rp50'));
   assert.ok(claimState.has('1'));
   await send('/', { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:' 08-123 456 789 0 ' } }] } }] }] });
   assert.strictEqual(ewalletCalls.length,1);
@@ -58,4 +55,5 @@ test('claim approval asks for ewallet and stores number', async () => {
   assert.strictEqual(messages[1].type,'buttons');
   assert.strictEqual(messages[1].args[1],'Nomor ShopeePay diterima: 081234567890. Refund diproses maksimal 2×24 jam.');
   await new Promise(r=>server.close(r));
+  claims.setEwallet = origSet;
 });

--- a/test/wa-claim-flow.test.js
+++ b/test/wa-claim-flow.test.js
@@ -4,7 +4,6 @@ const express = require('express');
 
 process.env.WA_APP_SECRET = '';
 const waPath = require.resolve('../src/services/wa');
-const claimPath = require.resolve('../src/services/claims');
 const dbPath = require.resolve('../src/db/client');
 const tgPath = require.resolve('../src/services/telegram');
 
@@ -14,38 +13,59 @@ require.cache[waPath] = { exports: {
   sendInteractiveButtons: async (...args) => { messages.push({ type: 'buttons', args }); },
   sendListMenu: async () => {},
 } };
-require.cache[claimPath] = { exports: { createClaim: async (invoice, reason) => { messages.push({ type: 'claim', invoice, reason }); }, setEwallet: async () => {} } };
 require.cache[tgPath] = { exports: { sendMessage: async () => {}, buildOrderKeyboard: () => ({}) } };
 require.cache[dbPath] = { exports: {
   orders: {
     findUnique: async ({ where }) => {
       if (where.invoice !== 'INV-1') return null;
-      return { invoice: 'INV-1', status: 'DELIVERED', amount_cents: 10000, created_at: new Date(Date.now()-5*86400000), product:{ name:'Prod', duration_months:1 } };
+      return { invoice: 'INV-1', status: 'DELIVERED', amount_cents: 10000, created_at: new Date(Date.now() - 5 * 86400000), product: { name: 'Prod', duration_months: 1 } };
     },
     findFirst: async () => null,
   },
 } };
 
-const waWebhook = require('../src/whatsapp/webhook');
+const claims = require('../src/services/claims');
 
 function startApp() {
+  const waWebhook = require('../src/whatsapp/webhook');
   const app = express();
-  app.use(express.json({ verify:(req,_res,buf)=>{ req.rawBody=buf; } }));
+  app.use(express.json({ verify: (req, _res, buf) => { req.rawBody = buf; } }));
   app.use('/', waWebhook);
   return app;
 }
 
 test('claim flow triggers createClaim', async () => {
+  messages.length = 0;
+  const origCreate = claims.createClaim;
+  const origSet = claims.setEwallet;
+  claims.createClaim = async (invoice, reason) => { messages.push({ type: 'claim', invoice, reason }); };
+  claims.setEwallet = async () => {};
+
   const app = startApp();
   const server = app.listen(0); const port = server.address().port;
-  function send(body){ return fetch(`http://127.0.0.1:${port}/`, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) }); }
-  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b4', title:'🛡️ Klaim Garansi' } } }] } }] }] });
-  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'INV-1' } }] } }] }] });
-  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'interactive', interactive:{ button_reply:{ id:'b1', title:'Ajukan Klaim' } } }] } }] }] });
-  await send({ entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:'rusak' } }] } }] }] });
-  await new Promise(r=>server.close(r));
-  const claimCall = messages.find(m=>m.type==='claim');
+  function send(body) { return fetch(`http://127.0.0.1:${port}/`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }); }
+  await send({ entry: [{ changes: [{ value: { messages: [{ from: '1', type: 'interactive', interactive: { button_reply: { id: 'b4', title: '🛡️ Klaim Garansi' } } }] } }] }] });
+  await send({ entry: [{ changes: [{ value: { messages: [{ from: '1', type: 'text', text: { body: 'INV-1' } }] } }] }] });
+  await send({ entry: [{ changes: [{ value: { messages: [{ from: '1', type: 'interactive', interactive: { button_reply: { id: 'b1', title: 'Ajukan Klaim' } } }] } }] }] });
+  await send({ entry: [{ changes: [{ value: { messages: [{ from: '1', type: 'text', text: { body: 'rusak' } }] } }] }] });
+  await new Promise(r => server.close(r));
+
+  const claimCall = messages.find(m => m.type === 'claim');
   assert.ok(claimCall);
-  assert.strictEqual(claimCall.invoice,'INV-1');
-  assert.strictEqual(claimCall.reason,'rusak');
+  assert.strictEqual(claimCall.invoice, 'INV-1');
+  assert.strictEqual(claimCall.reason, 'rusak');
+  claims.createClaim = origCreate;
+  claims.setEwallet = origSet;
 });
+
+test('requestEwallet sends refund amount', async () => {
+  messages.length = 0;
+  const db = require.cache[dbPath].exports;
+  db.warrantyclaims = { findUnique: async () => ({ id: 1, refund_cents: 5000, order: { buyer_phone: '1' } }) };
+
+  await claims.requestEwallet(1);
+  assert.strictEqual(messages.length, 1);
+  assert.strictEqual(messages[0].type, 'text');
+  assert.ok(messages[0].args[1].includes('Rp50'));
+});
+


### PR DESCRIPTION
## Summary
- ensure claim approve/reject/refunded endpoints remain idempotent when repeated
- cover setEwallet validation, normalization, and repeat idempotency
- verify WA claim flow sends refund amount and stores normalized ewallet

## Testing
- `node --test test/claim-idempotent.test.js test/claim.test.js test/wa-claim-flow.test.js test/wa-claim-ewallet.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bec9dc4e7083299be9f4344c22508d