### PR TITLE
test: ensure otp tokens are single use

### DIFF
--- a/test/otp-manual-disney.test.js
+++ b/test/otp-manual-disney.test.js
@@ -30,7 +30,12 @@ test('manual OTP token only usable once', async () => {
   delete require.cache[otpPath];
   const { createManualToken, fulfillManualOtp } = require(otpPath);
 
-  const tokenId = await createManualToken(99, 1);
+  const tokenId = await createManualToken(99, 1); // TTL 1s
+
+  // Ensure TTL is applied roughly within 1 second
+  const ttlMs = tokens.get(tokenId).expires_at.getTime() - Date.now();
+  assert.ok(ttlMs > 0 && ttlMs <= 1000);
+
   const order = await fulfillManualOtp(tokenId, '123456');
 
   assert.strictEqual(order, 99);

--- a/test/otp-totp-chatgpt.test.js
+++ b/test/otp-totp-chatgpt.test.js
@@ -36,4 +36,13 @@ test('single-use TOTP only generated once per order', async () => {
   const second = await generateSingleUseTOTP(7, secret);
   assert.strictEqual(second, null);
   assert.strictEqual(tokens.size, 1);
+
+  // Generated token is immediately marked used once
+  const record = [...tokens.values()][0];
+  assert.strictEqual(record.used, true);
+  assert.strictEqual(record.used_count, 1);
+
+  // TTL is short (<= step size)
+  const ttlMs = record.expires_at.getTime() - Date.now();
+  assert.ok(ttlMs > 0 && ttlMs <= 30000);
 });


### PR DESCRIPTION
## Summary
- test manual OTP single-use tokens with short TTL
- test TOTP generator single-use per order

## Testing
- `npm test test/otp-manual-disney.test.js test/otp-totp-chatgpt.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf008ea994832982888514f0df4462