### PR TITLE
Filter disabled accounts out of orders and stock

### DIFF
--- a/src/services/orders.js
+++ b/src/services/orders.js
@@ -96,7 +96,7 @@ async function reserveAccount(orderId, variant_id, tx){
     if(!order) throw new Error('ORDER_NOT_FOUND');
     const [account] = await trx.$queryRaw`SELECT id, username, password, profile_name, profile_index, profile_pin, used_count, max_usage FROM accounts
       WHERE (variant_id = ${variant_id} OR (${variant_id} IS NULL AND product_code = ${order.product_code}))
-        AND status='AVAILABLE' AND used_count < max_usage
+        AND status='AVAILABLE' AND disabled=false AND deleted_at IS NULL AND used_count < max_usage
       ORDER BY fifo_order ASC, id ASC
       FOR UPDATE SKIP LOCKED LIMIT 1`;
     if(!account) throw new Error('OUT_OF_STOCK');

--- a/src/services/stock.js
+++ b/src/services/stock.js
@@ -3,8 +3,8 @@ const { publishStock } = require('./output');
 
 async function getStockSummary(){
   return prisma.$queryRaw`SELECT v.code,
-    COUNT(*) FILTER (WHERE a.status='AVAILABLE' AND a.used_count < a.max_usage) AS units,
-    COALESCE(SUM(GREATEST(0, a.max_usage - a.used_count) ) FILTER (WHERE a.status='AVAILABLE'),0) AS capacity
+    COUNT(*) FILTER (WHERE a.status='AVAILABLE' AND a.disabled=false AND a.deleted_at IS NULL AND a.used_count < a.max_usage) AS units,
+    COALESCE(SUM(GREATEST(0, a.max_usage - a.used_count) ) FILTER (WHERE a.status='AVAILABLE' AND a.disabled=false AND a.deleted_at IS NULL),0) AS capacity
     FROM product_variants v
     LEFT JOIN accounts a ON a.variant_id = v.variant_id
     GROUP BY v.code
@@ -13,8 +13,8 @@ async function getStockSummary(){
 
 async function getStockSummaryRaw(){
   return prisma.$queryRaw`SELECT v.code, v.variant_id,
-    COUNT(*) FILTER (WHERE a.status='AVAILABLE' AND a.used_count < a.max_usage) AS units,
-    COALESCE(SUM(GREATEST(0, a.max_usage - a.used_count) ) FILTER (WHERE a.status='AVAILABLE'),0) AS capacity
+    COUNT(*) FILTER (WHERE a.status='AVAILABLE' AND a.disabled=false AND a.deleted_at IS NULL AND a.used_count < a.max_usage) AS units,
+    COALESCE(SUM(GREATEST(0, a.max_usage - a.used_count) ) FILTER (WHERE a.status='AVAILABLE' AND a.disabled=false AND a.deleted_at IS NULL),0) AS capacity
     FROM product_variants v
     LEFT JOIN accounts a ON a.variant_id = v.variant_id
     GROUP BY v.code, v.variant_id`;


### PR DESCRIPTION
## Summary
- ignore disabled or deleted accounts when reserving for orders
- exclude disabled or deleted accounts from stock summaries
- sheet sync deletions mark accounts disabled and timestamped

## Testing
- `node --test test/sheet-sync-upsert.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf09efdf2c83298c43c4f6dd04c473