### PR TITLE
test: ensure claim idempotency and refund messaging

### DIFF
--- a/test/claim-idempotent.test.js
+++ b/test/claim-idempotent.test.js
@@ -45,10 +45,12 @@ test('claim endpoints idempotent after refund', async () => {
     let res = await send(path, body);
     let b = await res.json();
     assert.ok(b.idempotent);
+    assert.strictEqual(res.status,200);
     assert.strictEqual(updateCount,0);
     res = await send(path, body);
     b = await res.json();
     assert.ok(b.idempotent);
+    assert.strictEqual(res.status,200);
     assert.strictEqual(updateCount,0);
   }
 

--- a/test/claim.test.js
+++ b/test/claim.test.js
@@ -59,6 +59,8 @@ test('setEwallet normalizes number and idempotent on repeat', async () => {
   assert.strictEqual(r1.claim.status, 'AWAITING_REFUND');
   assert.strictEqual(updateCount,1);
 
+  assert.ok(!r1.idempotent);
+
   const r2 = await setEwallet(1, '081234567890');
   assert.ok(r2.idempotent);
   assert.strictEqual(updateCount,1);

--- a/test/wa-claim-ewallet.test.js
+++ b/test/wa-claim-ewallet.test.js
@@ -47,6 +47,7 @@ test('claim approval asks for ewallet and stores number', async () => {
   await send('/claims/1/request-ewallet', {});
   assert.strictEqual(messages.length,1);
   assert.ok(messages[0].args[1].includes('Rp50'));
+  assert.ok(messages[0].args[1].includes('Kirim nomor ShopeePay'));
   assert.ok(claimState.has('1'));
   await send('/', { entry:[{ changes:[{ value:{ messages:[{ from:'1', type:'text', text:{ body:' 08-123 456 789 0 ' } }] } }] }] });
   assert.strictEqual(ewalletCalls.length,1);

--- a/test/wa-claim-flow.test.js
+++ b/test/wa-claim-flow.test.js
@@ -67,5 +67,6 @@ test('requestEwallet sends refund amount', async () => {
   assert.strictEqual(messages.length, 1);
   assert.strictEqual(messages[0].type, 'text');
   assert.ok(messages[0].args[1].includes('Rp50'));
+  assert.ok(messages[0].args[1].includes('Kirim nomor ShopeePay'));
 });
 


### PR DESCRIPTION
## Summary
- add tests verifying claim endpoints remain idempotent on finalized claims
- validate e-wallet normalization and idempotent repeats
- assert WA refund requests mention amount and ShopeePay instructions

## Testing
- `node --test test/claim-idempotent.test.js test/claim.test.js test/wa-claim-flow.test.js test/wa-claim-ewallet.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bf5b8cea7c8329930455b93f55fe23