### PR TITLE
feat: add product service with jest testing

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,15 @@
+version = 1
+
+[[analyzers]]
+name = "javascript"
+enabled = true
+
+  [analyzers.config]
+  runtime_version = "18"
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true
+
+  [analyzers.config]
+  test_patterns = ["test/**"]

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+import js from '@eslint/js';
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'commonjs',
+      globals: {
+        jest: true,
+      },
+    },
+  },
+];

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deploy:migrate": "prisma migrate deploy",
     "db:push": "prisma db push",
     "seed": "node src/db/migrate/seed.js",
-    "test": "node --test"
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.19.2",
@@ -24,5 +24,11 @@
     "@prisma/client": "^5.22.0",
     "dotenv": "^16.3.1",
     "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.2.5"
   }
 }

--- a/server.js
+++ b/server.js
@@ -10,6 +10,7 @@ const variantsSync = require('./src/routes/variants-sync');
 const sheet1Webhook = require('./src/routes/sheet1-webhook');
 const preapprovals = require('./src/routes/preapprovals');
 const claims = require('./src/routes/claims');
+const products = require('./src/routes/products');
 const telegramWebhook = require('./src/telegram/webhook');
 const waWebhook = require('./src/whatsapp/webhook');
 const { startWorkers } = require('./src/services/worker');
@@ -27,17 +28,24 @@ app.use(compression());
 app.use(requestLogger());
 
 // Parse JSON and keep raw body for HMAC verification on WhatsApp webhook
-app.use(express.json({
-  limit: '512kb',
-  type: ['application/json', 'application/*+json'],
-  verify: (req, _res, buf) => { req.rawBody = buf; },
-}));
+app.use(
+  express.json({
+    limit: '512kb',
+    type: ['application/json', 'application/*+json'],
+    verify: (req, _res, buf) => {
+      req.rawBody = buf;
+    },
+  }),
+);
 
 // CORS
 app.use((req, res, next) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type,Authorization,X-Request-Id,X-Admin-Token');
+  res.setHeader(
+    'Access-Control-Allow-Headers',
+    'Content-Type,Authorization,X-Request-Id,X-Admin-Token',
+  );
   if (req.method === 'OPTIONS') return res.sendStatus(204);
   next();
 });
@@ -50,20 +58,36 @@ app.use('/api', variantsSync);
 app.use('/api', sheet1Webhook);
 app.use('/preapprovals', preapprovals);
 app.use('/claims', claims);
+app.use('/products', products);
 app.use('/webhook/wa', waWebhook);
 
-const tgPath = process.env.WEBHOOK_SECRET_PATH ? `/webhook/telegram/${process.env.WEBHOOK_SECRET_PATH}` : '/webhook/telegram';
+const tgPath = process.env.WEBHOOK_SECRET_PATH
+  ? `/webhook/telegram/${process.env.WEBHOOK_SECRET_PATH}`
+  : '/webhook/telegram';
 app.use(tgPath, telegramWebhook);
 
-app.get('/', (_req, res) => res.json({ ok: true, healthz: '/healthz', status: '/status', telegram_webhook: tgPath, wa_webhook: '/webhook/wa' }));
+app.get('/', (_req, res) =>
+  res.json({
+    ok: true,
+    healthz: '/healthz',
+    status: '/status',
+    telegram_webhook: tgPath,
+    wa_webhook: '/webhook/wa',
+  }),
+);
 
 // error handlers
-app.use((err, _req, res, next) => { if (err && err.type === 'entity.parse.failed') return res.status(400).json({ ok: false, error: 'INVALID_JSON' }); next(err); });
+app.use((err, _req, res, next) => {
+  if (err && err.type === 'entity.parse.failed')
+    return res.status(400).json({ ok: false, error: 'INVALID_JSON' });
+  next(err);
+});
 app.use((_req, res) => res.status(404).json({ ok: false, error: 'NOT_FOUND' }));
 
 const server = app.listen(PORT, async () => {
   console.log(`Node ${process.version} listening on :${PORT}`);
-  if (process.env.PUBLIC_URL) console.log(`Public URL: ${process.env.PUBLIC_URL}`);
+  if (process.env.PUBLIC_URL)
+    console.log(`Public URL: ${process.env.PUBLIC_URL}`);
   console.log(`Telegram webhook mounted at: ${tgPath}`);
   await migrateIfEnabled();
   await runGuard();

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const { getProductByCode } = require('../services/products');
+
+const router = express.Router();
+
+router.get('/:code', async (request, response) => {
+  try {
+    const { code } = request.params;
+    const product = await getProductByCode(code);
+    if (!product) {
+      return response.status(404).json({ ok: false, error: 'NOT_FOUND' });
+    }
+    return response.json({ ok: true, product });
+  } catch (error) {
+    return response
+      .status(500)
+      .json({ ok: false, error: 'INTERNAL_SERVER_ERROR' });
+  }
+});
+
+module.exports = router;

--- a/src/services/products.js
+++ b/src/services/products.js
@@ -1,0 +1,22 @@
+const prisma = require('../db/client');
+
+/**
+ * Get product by code.
+ * @param {string} productCode - Unique product code.
+ * @returns {Promise<object|null>} Promise resolving to product or null.
+ */
+async function getProductByCode(productCode) {
+  try {
+    const product = await prisma.products.findUnique({
+      where: { code: productCode },
+    });
+    return product;
+  } catch (error) {
+    console.error('getProductByCode error:', error);
+    throw error;
+  }
+}
+
+module.exports = {
+  getProductByCode,
+};

--- a/test/products.test.js
+++ b/test/products.test.js
@@ -1,0 +1,23 @@
+const prisma = require('../src/db/client');
+const { getProductByCode } = require('../src/services/products');
+
+jest.mock('../src/db/client', () => ({
+  products: { findUnique: jest.fn() },
+}));
+
+describe('getProductByCode', () => {
+  it('returns product when found', async () => {
+    const fakeProduct = { code: 'ABC', name: 'Test Product' };
+    prisma.products.findUnique.mockResolvedValue(fakeProduct);
+    const result = await getProductByCode('ABC');
+    expect(prisma.products.findUnique).toHaveBeenCalledWith({
+      where: { code: 'ABC' },
+    });
+    expect(result).toEqual(fakeProduct);
+  });
+
+  it('throws when prisma fails', async () => {
+    prisma.products.findUnique.mockRejectedValue(new Error('db error'));
+    await expect(getProductByCode('ERR')).rejects.toThrow('db error');
+  });
+});


### PR DESCRIPTION
## Summary
- configure DeepSource and code style tools
- add product service and route using Prisma with error handling
- add Jest unit test for product service

## Testing
- `npx prettier --check src/services/products.js src/routes/products.js test/products.test.js jest.config.cjs`
- `npx eslint src/routes/products.js src/services/products.js` (fails: Cannot find package '@eslint/js')
- `npm test` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7a807152c8329b34a2278ebe08613